### PR TITLE
Allow to create a read only role

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,12 @@
 
 - the geoDB client correctly refreshes the capabilities of the PostGREST server
 - geoDB now logs collection read events, if deliberately triggered by the user
+- it is now possible to create users that only have permission to read [#117]
 
 ### Fixes
 
-- database truncation now works as name suggests (#009)
-- cleaned up documentation (#110)
+- database truncation now works as name suggests [#009]
+- cleaned up documentation [#110]
 - fixed caching of capabilities [#108]
 
 ## v1.0.9

--- a/tests/sql/setup-groups.sql
+++ b/tests/sql/setup-groups.sql
@@ -66,6 +66,23 @@ GRANT SELECT, UPDATE, USAGE ON SEQUENCE public.geodb_user_databases_seq TO "test
 
 GRANT "test_group" TO "test_admin" WITH ADMIN OPTION;
 
+GRANT EXECUTE ON FUNCTION geodb_create_database TO "test_member";
+GRANT EXECUTE ON FUNCTION geodb_create_collection TO "test_member";
+GRANT EXECUTE ON FUNCTION geodb_get_grants TO "test_member";
+GRANT EXECUTE ON FUNCTION geodb_user_allowed TO "test_member";
+GRANT EXECUTE ON FUNCTION geodb_add_properties TO "test_member";
+GRANT EXECUTE ON FUNCTION geodb_group_publish_collection TO "test_member";
+GRANT EXECUTE ON FUNCTION geodb_group_publish_database TO "test_member";
+GRANT EXECUTE ON FUNCTION geodb_group_unpublish_database TO "test_member";
+GRANT EXECUTE ON FUNCTION geodb_group_unpublish_collection TO "test_member";
+
+GRANT EXECUTE ON FUNCTION geodb_create_collection TO "test_member_2";
+GRANT EXECUTE ON FUNCTION geodb_user_allowed TO "test_member_2";
+GRANT EXECUTE ON FUNCTION geodb_group_revoke TO "test_member_2";
+GRANT EXECUTE ON FUNCTION geodb_group_grant TO "test_member_2";
+GRANT EXECUTE ON FUNCTION geodb_add_properties TO "test_member_2";
+
+
 INSERT INTO geodb_user_info
 VALUES (100, 'test_admin', '2020-12-08', 'geodb-manage', '');
 INSERT INTO geodb_user_info

--- a/tests/sql/setup.sql
+++ b/tests/sql/setup.sql
@@ -6,43 +6,24 @@
 
 -- DROP TABLE public.land_use;
 
+SELECT geodb_register_user('geodb_user', 'geodb_user');
+SELECT geodb_register_user('geodb_user-with-hyphens', 'geodb_user-with-hyphens');
+SELECT geodb_register_user('geodb_user_read_only', 'geodb_user_read_only');
+
+REVOKE EXECUTE ON FUNCTION geodb_show_indexes(text) FROM geodb_user_read_only;
+REVOKE EXECUTE ON FUNCTION geodb_create_collection(text, json, text) FROM geodb_user_read_only;
+REVOKE EXECUTE ON FUNCTION geodb_create_collections(json) FROM geodb_user_read_only;
+REVOKE EXECUTE ON FUNCTION geodb_create_database(text) FROM geodb_user_read_only;
+
 ALTER ROLE geodb_admin IN DATABASE postgres SET search_path TO public;
 GRANT geodb_admin TO authenticator;
-
-CREATE ROLE "geodb_user" WITH
-    LOGIN
-    NOSUPERUSER
-    INHERIT
-    NOCREATEDB
-    NOCREATEROLE
-    NOREPLICATION;
-
-GRANT "geodb_user" TO postgres;
-GRANT "geodb_user" TO authenticator;
-
-CREATE ROLE "geodb_user-with-hyphens" WITH
-    LOGIN
-    NOSUPERUSER
-    INHERIT
-    NOCREATEDB
-    NOCREATEROLE
-    NOREPLICATION;
-
-GRANT "geodb_user-with-hyphens" TO postgres;
-GRANT "geodb_user-with-hyphens" TO authenticator;
-
-GRANT ALL ON SCHEMA public TO "geodb_user";
-GRANT ALL ON SCHEMA public TO "geodb_user-with-hyphens";
+GRANT EXECUTE ON FUNCTION geodb_create_role(text, text) TO geodb_admin;
 
 GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE public.geodb_user_databases TO "geodb_user";
 GRANT INSERT, SELECT, UPDATE, DELETE ON TABLE public.geodb_user_databases TO "geodb_user-with-hyphens";
 GRANT SELECT, UPDATE, USAGE ON SEQUENCE public.geodb_user_databases_seq TO "geodb_user";
 GRANT SELECT, UPDATE, USAGE ON SEQUENCE public.geodb_user_databases_seq TO "geodb_user-with-hyphens";
 
-INSERT INTO public.geodb_user_databases("name", "owner", "iss")
-VALUES ('geodb_user', 'geodb_user', '');
-INSERT INTO public.geodb_user_databases("name", "owner", "iss")
-VALUES ('geodb_user-with-hyphens', 'geodb_user-with-hyphens', '');
 INSERT INTO public.geodb_user_databases("name", "owner", "iss")
 VALUES ('postgres', 'postgres', '');
 

--- a/xcube_geodb/sql/geodb.sql
+++ b/xcube_geodb/sql/geodb.sql
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS public."geodb_version_info"
 );
 GRANT SELECT ON TABLE geodb_version_info TO PUBLIC;
 INSERT INTO geodb_version_info
-VALUES (DEFAULT, 'VERSION_PLACEHOLDER', now());
+VALUES (DEFAULT, '1.0.10dev', now());
 -- if manually setting up the database, this might be necessary to clean up:
 DELETE
 FROM geodb_version_info
@@ -1538,10 +1538,12 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP EVENT TRIGGER IF EXISTS pgrst_ddl_watch;
 CREATE EVENT TRIGGER pgrst_ddl_watch
     ON ddl_command_end
 EXECUTE PROCEDURE pgrst_ddl_watch();
 
+DROP EVENT TRIGGER IF EXISTS pgrst_drop_watch;
 CREATE EVENT TRIGGER pgrst_drop_watch
     ON sql_drop
 EXECUTE PROCEDURE pgrst_drop_watch();

--- a/xcube_geodb/sql/geodb.sql
+++ b/xcube_geodb/sql/geodb.sql
@@ -4,7 +4,6 @@ CREATE SCHEMA IF NOT EXISTS geodb_user_info;
 
 -- cleanup litter of previous versions
 
-DROP FUNCTION IF EXISTS public.geodb_check_user();
 DROP FUNCTION IF EXISTS public.geodb_check_user_grants(text);
 DROP FUNCTION IF EXISTS public.geodb_copy_collection2(text, text);
 DROP FUNCTION IF EXISTS public.geodb_copy_collection3(text, text);
@@ -25,6 +24,22 @@ DROP FUNCTION IF EXISTS public.geodb_remove_index(text, text);
 DROP FUNCTION IF EXISTS public.geodb_test_exception();
 
 -- cleanup end
+
+-- do not remove - this function is called from PostGREST before any database query is done
+CREATE OR REPLACE FUNCTION public.geodb_check_user()
+    RETURNS void
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+AS
+$$
+BEGIN
+    IF current_user = 'anonymous' THEN
+        RAISE SQLSTATE 'PT403' USING DETAIL = 'Anonymous users do not have access.',
+            HINT = 'Access denied.';
+    END IF;
+END
+$$;
 
 
 CREATE SEQUENCE IF NOT EXISTS public.geodb_user_info_id_seq

--- a/xcube_geodb/sql/geodb.sql
+++ b/xcube_geodb/sql/geodb.sql
@@ -4,23 +4,24 @@ CREATE SCHEMA IF NOT EXISTS geodb_user_info;
 
 -- cleanup litter of previous versions
 
-DROP FUNCTION IF EXISTS public.geodb_check_user(text);
+DROP FUNCTION IF EXISTS public.geodb_check_user();
 DROP FUNCTION IF EXISTS public.geodb_check_user_grants(text);
-DROP FUNCTION IF EXISTS public.geodb_copy_collection2(text);
-DROP FUNCTION IF EXISTS public.geodb_copy_collection3(text);
+DROP FUNCTION IF EXISTS public.geodb_copy_collection2(text, text);
+DROP FUNCTION IF EXISTS public.geodb_copy_collection3(text, text);
 DROP FUNCTION IF EXISTS public.geodb_dashboard_view_query(text);
-DROP FUNCTION IF EXISTS public.geodb_extract_database(text);
+DROP FUNCTION IF EXISTS public.geodb_extract_database(text, text);
 DROP FUNCTION IF EXISTS public.geodb_get_geodb_version();
 DROP FUNCTION IF EXISTS public.geodb_get_mvt();
 DROP FUNCTION IF EXISTS public.geodb_get_mvt_geom();
-DROP FUNCTION IF EXISTS public.geodb_get_nearest(text, double precision, double precision, integer, text,
-                                                 text, text, integer);
+DROP FUNCTION IF EXISTS public.geodb_get_nearest(text, float8, float8, int4, text,
+                                                 text, text, int4, int4);
 DROP FUNCTION IF EXISTS public.geodb_grant_user_admin(text);
 DROP FUNCTION IF EXISTS public.geodb_group_users(text);
 DROP FUNCTION IF EXISTS public.geodb_list_users();
 DROP FUNCTION IF EXISTS public.geodb_log_sizes();
-DROP FUNCTION IF EXISTS public.geodb_reassign_owned();
-DROP FUNCTION IF EXISTS public.geodb_remove_index();
+DROP FUNCTION IF EXISTS public.geodb_reassign_owned(text, text);
+DROP FUNCTION IF EXISTS public.geodb_remove_index(text);
+DROP FUNCTION IF EXISTS public.geodb_remove_index(text, text);
 DROP FUNCTION IF EXISTS public.geodb_test_exception();
 
 -- cleanup end
@@ -788,7 +789,7 @@ BEGIN
                pg_catalog.pg_get_function_identity_arguments(p.oid) AS arg_types
         FROM pg_proc p
                  JOIN pg_namespace pgn ON p.pronamespace = pgn.oid
-        WHERE p.proname LIKE 'geodb_%'
+        WHERE p.proname LIKE '%geodb_%'
           AND pgn.nspname NOT IN ('pg_catalog', 'information_schema')
           AND p.proname NOT IN ('geodb_get_user_roles', 'geodb_get_user_usage')
         LOOP


### PR DESCRIPTION
This PR will allow admins to create a role that can only read. The prerequisite is that not all functions and tables are exposed to the public -- this prerequisite is fulfilled by the changes in this PR, which closes https://github.com/xcube-dev/xcube-geodb/issues/117. 

Checklist:

* [x] Issue has been created for change
* dna - Added docstrings and API docs for any new/modified user-facing classes and functions
* dna - New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] Test coverage remains or increases (target 100%)