### PR TITLE
Allow geoDB users to set and retrieve STAC compliant metadata

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -93,8 +93,11 @@ jobs:
       - name: test-notebooks
         shell: bash -l {0}
         working-directory: docs/source/notebooks
+        # excluding metadata from run as it needs the public geoDB. Add it back in
+        # as soon as the branch is merged to main, and the SQL on the public geoDB
+        # supports metadata functionalities.
         run: |
-          for nb in $(ls *.ipynb)
+          for nb in $(ls *.ipynb | grep -v metadata)
           do
             papermill $nb  $(basename -s .ipynb $nb)_out.ipynb
           done

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -93,11 +93,8 @@ jobs:
       - name: test-notebooks
         shell: bash -l {0}
         working-directory: docs/source/notebooks
-        # excluding metadata from run as it needs the public geoDB. Add it back in
-        # as soon as the branch is merged to main, and the SQL on the public geoDB
-        # supports metadata functionalities.
         run: |
-          for nb in $(ls *.ipynb | grep -v metadata)
+          for nb in $(ls *.ipynb)
           do
             papermill $nb  $(basename -s .ipynb $nb)_out.ipynb
           done

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -93,8 +93,11 @@ jobs:
       - name: test-notebooks
         shell: bash -l {0}
         working-directory: docs/source/notebooks
+        # running only metadata-notebook in this branch. Add the others back in
+        # as soon as the branch is merged to main, and the SQL on the public geoDB
+        # supports metadata functionalities.
         run: |
-          for nb in $(ls *.ipynb)
+          for nb in $(ls *.ipynb | grep metadata)
           do
             papermill $nb  $(basename -s .ipynb $nb)_out.ipynb
           done

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
-## v1.0.11 (in development)
+## v1.1.0
 
 ### New Features
+
+- allow to store metadata for collections [#123]
 
 ### Fixes
 

--- a/docs/source/notebooks/geodb_explore_collections.ipynb
+++ b/docs/source/notebooks/geodb_explore_collections.ipynb
@@ -38,13 +38,7 @@
     "### uncomment if not in managed environment\n",
     "#client_id=YourID\n",
     "#client_secret=YourSecret\n",
-    "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")\n",
-    "\n",
-    "\n",
-    "# remove the following two lines when merging into main!\n",
-    "import os\n",
-    "\n",
-    "os.environ[\"GEODB_API_SERVER_URL\"] = \"https://xcube-geodb.dev.brockmann-consult.de\""
+    "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")"
    ]
   },
   {

--- a/docs/source/notebooks/geodb_explore_collections.ipynb
+++ b/docs/source/notebooks/geodb_explore_collections.ipynb
@@ -38,7 +38,13 @@
     "### uncomment if not in managed environment\n",
     "#client_id=YourID\n",
     "#client_secret=YourSecret\n",
-    "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")"
+    "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")\n",
+    "\n",
+    "\n",
+    "# remove the following two lines when merging into main!\n",
+    "import os\n",
+    "\n",
+    "os.environ[\"GEODB_API_SERVER_URL\"] = \"https://xcube-geodb.dev.brockmann-consult.de\""
    ]
   },
   {
@@ -172,18 +178,17 @@
     "import geopandas\n",
     "\n",
     "collections = {\n",
-    "        \"land_use\":\n",
+    "    \"land_use\":\n",
     "        {\n",
     "            \"crs\": 3794,\n",
     "            \"properties\":\n",
-    "            {\n",
-    "                \"RABA_PID\": \"float\",\n",
-    "                \"RABA_ID\": \"float\",\n",
-    "                \"D_OD\": \"date\"\n",
-    "            }\n",
+    "                {\n",
+    "                    \"RABA_PID\": \"float\",\n",
+    "                    \"RABA_ID\": \"float\",\n",
+    "                    \"D_OD\": \"date\"\n",
+    "                }\n",
     "        }\n",
-    "    }\n",
-    "\n",
+    "}\n",
     "\n",
     "geodb.create_collections(collections, clear=True)\n",
     "\n"
@@ -214,7 +219,8 @@
    ],
    "source": [
     "gdf = geopandas.read_file('data/sample/land_use.shp')\n",
-    "geodb.insert_into_collection('land_use', gdf.iloc[:100,:]) # minimizing rows to 100, if you are in EDC, you dont need to make the subset."
+    "geodb.insert_into_collection('land_use', gdf.iloc[\n",
+    "    :100, :])  # minimizing rows to 100, if you are in EDC, you dont need to make the subset."
    ]
   },
   {
@@ -246,9 +252,7 @@
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "geodb.get_my_usage() # to be updated so that all available collections are displayed includign sensible information ont heir availability, e.g. public, purchased, etc.."
-   ]
+   "source": "geodb.get_my_usage()  # to be updated so that all available collections are displayed includign sensible information ont heir availability, e.g. public, purchased, etc.."
   },
   {
    "cell_type": "code",
@@ -527,7 +531,8 @@
     }
    ],
    "source": [
-    "gdf = geodb.get_collection('land_use') # to be updated, so that namespace is not needed or something more suitable, e.g. 'public'\n",
+    "gdf = geodb.get_collection(\n",
+    "    'land_use')  # to be updated, so that namespace is not needed or something more suitable, e.g. 'public'\n",
     "gdf"
    ]
   },
@@ -570,9 +575,7 @@
      "output_type": "display_data"
     }
    ],
-   "source": [
-    "gdf.plot(column=\"raba_id\", figsize=(15,15), cmap = 'jet')"
-   ]
+   "source": "gdf.plot(column=\"raba_id\", figsize=(15, 15), cmap='jet')"
   },
   {
    "cell_type": "markdown",
@@ -732,9 +735,7 @@
      "output_type": "display_data"
     }
    ],
-   "source": [
-    "gdfsub.plot(column=\"raba_id\", figsize=(15,15), cmap = 'jet')"
-   ]
+   "source": "gdfsub.plot(column=\"raba_id\", figsize=(15, 15), cmap='jet')"
   },
   {
    "cell_type": "markdown",
@@ -943,7 +944,8 @@
     }
    ],
    "source": [
-    "gdf = geodb.get_collection_by_bbox(collection=\"land_use\",  bbox = (452750.0, 88909.549, 464000.0, 102486.299), comparison_mode=\"contains\", bbox_crs=3794, limit=200, offset=10)\n",
+    "gdf = geodb.get_collection_by_bbox(collection=\"land_use\", bbox=(452750.0, 88909.549, 464000.0, 102486.299),\n",
+    "                                   comparison_mode=\"contains\", bbox_crs=3794, limit=200, offset=10)\n",
     "gdf"
    ]
   },
@@ -975,9 +977,7 @@
      "output_type": "display_data"
     }
    ],
-   "source": [
-    "gdf.plot(column=\"raba_pid\", figsize=(15,15), cmap = 'jet')"
-   ]
+   "source": "gdf.plot(column=\"raba_pid\", figsize=(15, 15), cmap='jet')"
   },
   {
    "cell_type": "markdown",
@@ -1137,9 +1137,7 @@
      "output_type": "display_data"
     }
    ],
-   "source": [
-    "gdf.plot(column=\"raba_pid\", figsize=(15,15), cmap = 'jet')"
-   ]
+   "source": "gdf.plot(column=\"raba_pid\", figsize=(15, 15), cmap='jet')"
   },
   {
    "cell_type": "markdown",

--- a/docs/source/notebooks/geodb_group_management.ipynb
+++ b/docs/source/notebooks/geodb_group_management.ipynb
@@ -9,7 +9,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "f07bb02d735a4147"
   },
   {
    "cell_type": "code",
@@ -18,7 +19,8 @@
    "outputs": [],
    "source": [
     "from xcube_geodb.core.geodb import GeoDBClient"
-   ]
+   ],
+   "id": "8adda0511e4e5a0f"
   },
   {
    "cell_type": "markdown",
@@ -29,7 +31,8 @@
     "Install xcube geoDB with command:\n",
     "  \n",
     " `conda install xcube_geodb -c conda-forge`\n"
-   ]
+   ],
+   "id": "ef34c488b37a66b7"
   },
   {
    "cell_type": "code",
@@ -40,8 +43,14 @@
     "### uncomment if not in managed environment\n",
     "#client_id=YourID\n",
     "#client_secret=YourSecret\n",
-    "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")"
-   ]
+    "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")\n",
+    "\n",
+    "# remove the following two lines when merging into main!\n",
+    "import os\n",
+    "\n",
+    "os.environ[\"GEODB_API_SERVER_URL\"] = \"https://xcube-geodb.dev.brockmann-consult.de\""
+   ],
+   "id": "24296631768a10f"
   },
   {
    "cell_type": "markdown",
@@ -50,7 +59,8 @@
     "## Login in managed environment\n",
     "\n",
     "The environment is prepared with your user credentials, so you simply can start the client."
-   ]
+   ],
+   "id": "d73abec67797472b"
   },
   {
    "cell_type": "code",
@@ -59,7 +69,8 @@
    "outputs": [],
    "source": [
     "geodb = GeoDBClient()"
-   ]
+   ],
+   "id": "aeb0561413648ad5"
   },
   {
    "cell_type": "markdown",
@@ -68,7 +79,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "110f832b5257630c"
   },
   {
    "cell_type": "code",
@@ -80,7 +92,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "8b099d7d0ddf023b"
   },
   {
    "cell_type": "markdown",
@@ -89,7 +102,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "faf2e7ea411be60c"
   },
   {
    "cell_type": "code",
@@ -97,13 +111,14 @@
    "outputs": [],
    "source": [
     "group_name = 'test_group_' + geodb.whoami\n",
-    "group_name = group_name[:63] # ensure group_name will not be truncated in database\n",
+    "group_name = group_name[:63]  # ensure group_name will not be truncated in database\n",
     "if group_name not in geodb.get_my_groups():\n",
     "    geodb.create_group(group_name)\n"
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "22854a5d4b7b1245"
   },
   {
    "cell_type": "markdown",
@@ -112,7 +127,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "9918289ed3db22ba"
   },
   {
    "cell_type": "code",
@@ -124,7 +140,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "c07dc584e05340e3"
   },
   {
    "cell_type": "code",
@@ -135,7 +152,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "5de6077a2bc913be"
   },
   {
    "cell_type": "markdown",
@@ -144,7 +162,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "1e3c64e2b4b9d5e5"
   },
   {
    "cell_type": "code",
@@ -167,7 +186,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "c744aa60db0c1c41"
   },
   {
    "cell_type": "markdown",
@@ -176,7 +196,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "86836deb160cf925"
   },
   {
    "cell_type": "code",
@@ -188,7 +209,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "eea0feb76233c37e"
   },
   {
    "cell_type": "markdown",
@@ -197,7 +219,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "6d3c03450d28d58a"
   },
   {
    "cell_type": "code",
@@ -208,7 +231,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "6cd83a09fdea06b"
   },
   {
    "cell_type": "markdown",
@@ -217,7 +241,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "20d26ec6134d08bf"
   },
   {
    "cell_type": "code",
@@ -229,7 +254,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "51663958edd559c8"
   },
   {
    "cell_type": "markdown",
@@ -238,7 +264,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "5a0538d90294ec78"
   },
   {
    "cell_type": "code",
@@ -249,7 +276,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "ddfc68b4ac0c8b96"
   },
   {
    "cell_type": "markdown",
@@ -258,7 +286,8 @@
    ],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "id": "d68baa5efcdc901f"
   },
   {
    "cell_type": "code",

--- a/docs/source/notebooks/geodb_group_management.ipynb
+++ b/docs/source/notebooks/geodb_group_management.ipynb
@@ -43,12 +43,7 @@
     "### uncomment if not in managed environment\n",
     "#client_id=YourID\n",
     "#client_secret=YourSecret\n",
-    "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")\n",
-    "\n",
-    "# remove the following two lines when merging into main!\n",
-    "import os\n",
-    "\n",
-    "os.environ[\"GEODB_API_SERVER_URL\"] = \"https://xcube-geodb.dev.brockmann-consult.de\""
+    "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")"
    ],
    "id": "24296631768a10f"
   },

--- a/docs/source/notebooks/geodb_manage_collections.ipynb
+++ b/docs/source/notebooks/geodb_manage_collections.ipynb
@@ -38,12 +38,7 @@
     "### uncomment if not in managed environment\n",
     "#client_id=YourID\n",
     "#client_secret=YourSecret\n",
-    "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")\n",
-    "\n",
-    "# remove the following two lines when merging into main!\n",
-    "import os\n",
-    "\n",
-    "os.environ[\"GEODB_API_SERVER_URL\"] = \"https://xcube-geodb.dev.brockmann-consult.de\""
+    "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")"
    ]
   },
   {

--- a/docs/source/notebooks/geodb_manage_collections.ipynb
+++ b/docs/source/notebooks/geodb_manage_collections.ipynb
@@ -38,7 +38,12 @@
     "### uncomment if not in managed environment\n",
     "#client_id=YourID\n",
     "#client_secret=YourSecret\n",
-    "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")"
+    "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")\n",
+    "\n",
+    "# remove the following two lines when merging into main!\n",
+    "import os\n",
+    "\n",
+    "os.environ[\"GEODB_API_SERVER_URL\"] = \"https://xcube-geodb.dev.brockmann-consult.de\""
    ]
   },
   {
@@ -184,18 +189,17 @@
    "source": [
     "# Have a look at fiona feature schema\n",
     "collections = {\n",
-    "        \"land_use\":\n",
+    "    \"land_use\":\n",
     "        {\n",
     "            \"crs\": 3794,\n",
     "            \"properties\":\n",
-    "            {\n",
-    "                \"RABA_PID\": \"float\",\n",
-    "                \"RABA_ID\": \"float\",\n",
-    "                \"D_OD\": \"date\"\n",
-    "            }\n",
+    "                {\n",
+    "                    \"RABA_PID\": \"float\",\n",
+    "                    \"RABA_ID\": \"float\",\n",
+    "                    \"D_OD\": \"date\"\n",
+    "                }\n",
     "        }\n",
-    "    }\n",
-    "\n",
+    "}\n",
     "\n",
     "geodb.create_collections(collections, clear=True)"
    ]
@@ -361,6 +365,7 @@
    ],
    "source": [
     "import geopandas\n",
+    "\n",
     "gdf = geopandas.read_file('data/sample/land_use.shp')\n",
     "gdf"
    ]
@@ -382,7 +387,8 @@
     }
    ],
    "source": [
-    "geodb.insert_into_collection('land_use', gdf.iloc[:100,:]) # minimizing rows to 100, if you are in EDC, you dont need to make the subset."
+    "geodb.insert_into_collection('land_use', gdf.iloc[\n",
+    "    :100, :])  # minimizing rows to 100, if you are in EDC, you dont need to make the subset."
    ]
   },
   {

--- a/docs/source/notebooks/geodb_test_metadata_support.ipynb
+++ b/docs/source/notebooks/geodb_test_metadata_support.ipynb
@@ -202,7 +202,7 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "Finally, show the complete metadata stored for the collection:"
+   "source": "Show the complete metadata stored for the collection:"
   },
   {
    "metadata": {},
@@ -225,6 +225,29 @@
     "print(f\"stac_extensions: {md.stac_extensions}\")\n",
     "print(f\"stac_version: {md.stac_version}\")"
    ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Finally, clean up:"
+  },
+  {
+   "metadata": {
+    "jupyter": {
+     "is_executing": true
+    }
+   },
+   "cell_type": "code",
+   "source": "geodb.drop_collection(collection_name)",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "",
    "outputs": [],
    "execution_count": null
   }

--- a/docs/source/notebooks/geodb_test_metadata_support.ipynb
+++ b/docs/source/notebooks/geodb_test_metadata_support.ipynb
@@ -16,13 +16,17 @@
     "from xcube_geodb.core.metadata import Link, Provider, Asset, ItemAsset\n",
     "from xcube_geodb.core.geodb import GeoDBClient\n",
     "import geopandas\n",
+    "import os\n",
     "\n",
     "### uncomment if not in managed environment\n",
     "#client_id=YourID\n",
     "#client_secret=YourSecret\n",
     "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")\n",
     "\n",
-    "geodb = GeoDBClient()"
+    "os.environ[\"GEODB_API_SERVER_URL\"] = \"https://xcube-geodb.dev.brockmann-consult.de\"\n",
+    "\n",
+    "geodb = GeoDBClient()\n",
+    "geodb.whoami"
    ],
    "outputs": [],
    "execution_count": null
@@ -208,7 +212,7 @@
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "md = geodb.get_metadata(\"collection_name\")\n",
+    "md = geodb.get_metadata(collection_name)\n",
     "print(f\"id: {md.id}\")\n",
     "print(f\"title: {md.title}\")\n",
     "print(f\"type: {md.type}\")\n",
@@ -234,20 +238,9 @@
    "source": "Finally, clean up:"
   },
   {
-   "metadata": {
-    "jupyter": {
-     "is_executing": true
-    }
-   },
-   "cell_type": "code",
-   "source": "geodb.drop_collection(collection_name)",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
    "metadata": {},
    "cell_type": "code",
-   "source": "",
+   "source": "geodb.drop_collection(collection_name)",
    "outputs": [],
    "execution_count": null
   }

--- a/docs/source/notebooks/geodb_test_metadata_support.ipynb
+++ b/docs/source/notebooks/geodb_test_metadata_support.ipynb
@@ -1,0 +1,253 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demonstration of setting and loading metadata\n",
+    "\n",
+    "This notebook demonstrates how [STAC](https://github.com/radiantearth/stac-spec/tree/master/collection-spec)-compliant metadata can stored in and retrieved from the geoDB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from xcube_geodb.core.metadata import Link, Provider, Asset, ItemAsset\n",
+    "from xcube_geodb.core.geodb import GeoDBClient\n",
+    "import geopandas\n",
+    "\n",
+    "### uncomment if not in managed environment\n",
+    "#client_id=YourID\n",
+    "#client_secret=YourSecret\n",
+    "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")\n",
+    "\n",
+    "geodb = GeoDBClient()"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Prepare a collection which we use for setting and retrieving metadata:"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "collection_name = \"metadata_test\"\n",
+    "collections = {\n",
+    "    collection_name:\n",
+    "        {\n",
+    "            \"crs\": 3794,\n",
+    "            \"properties\":\n",
+    "                {\n",
+    "                    \"name\": \"text\",\n",
+    "                    \"day\": \"date\"\n",
+    "                }\n",
+    "        }\n",
+    "}\n",
+    "\n",
+    "geodb.create_collections(collections, clear=True)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "In the following cells, set and retrieve different metadata properties:"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "geodb.set_metadata_field(\"title\", \"my title\", collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.title)\n",
+    "geodb.set_metadata_field(\"title\", '\"my other title\"', collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.title)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "geodb.set_metadata_field(\"description\", \"my description\", collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.description)\n",
+    "geodb.set_metadata_field(\"description\", 'my other description', collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.description)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "geodb.set_metadata_field(\"license\", \"my license\", collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.license)\n",
+    "geodb.set_metadata_field(\"license\", 'just use it', collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.license)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "geodb.set_metadata_field(\"links\", [Link.from_json({'href': 'https://link.bc', 'rel': 'parent'}),\n",
+    "                                   Link.from_json({'href': 'https://link2.bc', 'rel': 'root'})], collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.links)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "geodb.set_metadata_field(\"keywords\", ['crops', 'europe', 'rural'], collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.keywords)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "geodb.set_metadata_field(\"stac_extensions\", ['https://stac-extensions.github.io/authentication/v1.1.0/schema.json'],\n",
+    "                         collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.stac_extensions)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "geodb.set_metadata_field(\"providers\", [Provider.from_json(\n",
+    "    {'name': 'provider 1', 'description': 'some provider', 'roles': ['licensor', 'producer']})], collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.providers)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "geodb.set_metadata_field(\"summaries\", {'columns': ['id', 'geometry'], 'x_range': {'min': '-170', 'max': '170'},\n",
+    "                                       'y_range': {'min': '-80', 'max': '80'}, 'schema': 'some JSON schema'},\n",
+    "                         collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.summaries)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "geodb.set_metadata_field(\"assets\", [Asset.from_json(\n",
+    "    {'href': 'https://asset.org', 'title': 'some title', 'roles': ['image', 'ql']}), Asset.from_json(\n",
+    "    {'href': 'https://asset2.org', 'title': 'some other title', 'roles': ['image']})], collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.assets)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "geodb.set_metadata_field(\"item_assets\", [ItemAsset.from_json({'href': 'https://asset.org', 'type': 'some type'})],\n",
+    "                         collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.item_assets)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "geodb.set_metadata_field(\"temporal_extent\",\n",
+    "                         [['2018-01-01T00:00:00Z', None], ['2019-01-01T00:00:00Z', '2019-01-02T00:00:00Z']],\n",
+    "                         collection_name)\n",
+    "md = geodb.get_metadata(collection_name)\n",
+    "print(md.temporal_extent)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Finally, show the complete metadata stored for the collection:"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "md = geodb.get_metadata(\"collection_name\")\n",
+    "print(f\"id: {md.id}\")\n",
+    "print(f\"title: {md.title}\")\n",
+    "print(f\"type: {md.type}\")\n",
+    "print(f\"description: {md.description}\")\n",
+    "print(f\"license: {md.license}\")\n",
+    "print(f\"keywords: {md.keywords}\")\n",
+    "print(f\"links: {md.links}\")\n",
+    "print(f\"assets: {md.assets}\")\n",
+    "print(f\"item_assets: {md.item_assets}\")\n",
+    "print(f\"spatial_extent: {md.spatial_extent}\")\n",
+    "print(f\"temporal_extent: {md.temporal_extent}\")\n",
+    "print(f\"summaries: {md.summaries}\")\n",
+    "print(f\"providers: {md.providers}\")\n",
+    "print(f\"stac_extensions: {md.stac_extensions}\")\n",
+    "print(f\"stac_version: {md.stac_version}\")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/notebooks/geodb_test_metadata_support.ipynb
+++ b/docs/source/notebooks/geodb_test_metadata_support.ipynb
@@ -23,6 +23,7 @@
     "#client_secret=YourSecret\n",
     "#geodb = GeoDBClient(client_id=client_id, client_secret=client_secret, auth_mode=\"client-credentials\")\n",
     "\n",
+    "# remove the following line when merging into main!\n",
     "os.environ[\"GEODB_API_SERVER_URL\"] = \"https://xcube-geodb.dev.brockmann-consult.de\"\n",
     "\n",
     "geodb = GeoDBClient()\n",

--- a/tests/core/geodb_test_base.py
+++ b/tests/core/geodb_test_base.py
@@ -1,0 +1,74 @@
+import json
+
+import requests_mock
+
+from tests.utils import del_env
+from xcube_geodb.core.geodb import GeoDBClient
+
+TEST_GEOM = (
+    "0103000020D20E000001000000110000007593188402B51B4"
+    "1B6F3FDD4423FF6405839B4C802B51B412B8716D9EC3EF6406"
+    "F1283C0EBB41B41A8C64B37C53EF640B6F3FDD4E4B41B419A999"
+    "999A33EF6400E2DB29DCFB41B41EE7C3F35B63EF6407F6ABC"
+    "74C0B41B41EE7C3F35B63EF6407B14AE47BDB41B41AAF1D24D"
+    "043FF6408B6CE77B64B41B413F355EBA8F3FF6402B8716D970"
+    "B41B41986E1283EC3FF640A4703D0A76B41B4179E92631AE3F"
+    "F6404260E5D08AB41B4123DBF97E923FF6409EEFA7C69CB41"
+    "B4100000000AC3FF6405839B448B3B41B411D5A643B973FF6"
+    "408195438BC6B41B41666666666C3FF640D122DBF9E3B41B4"
+    "139B4C876383FF640E9263188F8B41B41333333333D3FF64075"
+    "93188402B51B41B6F3FDD4423FF640"
+)
+
+
+# noinspection DuplicatedCode
+@requests_mock.mock(real_http=False)
+class GeoDBClientTestBase:
+    def setUp(self) -> None:
+        self._api = GeoDBClient(
+            dotenv_file="tests/envs/.env_test",
+            config_file="tests/.geodb",
+            raise_it=True,
+        )
+
+        self._server_test_url = self._api._server_url
+        self._server_test_port = self._api._server_port
+        self._base_url = self._server_test_url
+        if self._server_test_port:
+            self._base_url += ":" + str(self._server_test_port)
+        self._gs_server_url = self._api._gs_server_url
+        self._gs_server_port = self._api._gs_server_port
+
+        self._server_test_auth_domain = "https://winchester.deployment"
+
+    def tearDown(self) -> None:
+        del_env(dotenv_path="tests/envs/.env_test")
+
+    def set_global_mocks(self, m):
+        m.post(
+            self._server_test_auth_domain + "/oauth/token",
+            json={"access_token": "A long lived token", "expires_in": 12345},
+        )
+
+        url = f"{self._base_url}/rpc/geodb_whoami"
+        m.get(url, text=json.dumps("helge"))
+
+        url = f"{self._base_url}/rpc/geodb_get_collection_srid"
+        m.post(url, json=[{"src": [{"srid": 4326}]}])
+
+        url = f"{self._base_url}/rpc/geodb_log_event"
+        m.post(url, text=json.dumps(""))
+
+    def set_auth_change_mocks(self, m):
+        m.post(
+            self._server_test_auth_domain + "/oauth/token",
+            json={
+                "access_token": "A long lived token but a different user",
+                "expires_in": 12345,
+            },
+        )
+
+        url = f"{self._base_url}/rpc/geodb_whoami"
+        m.get(url, text=json.dumps("pope"))
+
+        self._api._auth_client_id = "fsvsdv"

--- a/tests/core/test_geodb.py
+++ b/tests/core/test_geodb.py
@@ -7,7 +7,6 @@ import pandas as pd
 import requests
 import requests_mock
 from geopandas import GeoDataFrame
-from psycopg2 import OperationalError
 from requests_mock.mocker import Mocker
 from shapely import wkt, Polygon
 
@@ -2124,30 +2123,6 @@ class GeoDBClientTest(unittest.TestCase):
             warn("test")
 
         self.assertEqual("test", str(e.warning))
-
-    @unittest.skip
-    def test_setup(self, m):
-        geodb = GeoDBClient()
-        with self.assertRaises(OperationalError) as e:
-            geodb.setup()
-
-        self.assertIn("could not connect to server", str(e.exception))
-
-        # noinspection PyPep8Naming
-        class cn:
-            @staticmethod
-            def commit():
-                return True
-
-            # noinspection PyPep8Naming
-            class cursor:
-                @staticmethod
-                def execute(qry):
-                    return True
-
-        cn.cursor.execute = MagicMock()
-        geodb.setup(conn=cn)
-        cn.cursor.execute.assert_called_once()
 
     def test_df_from_json(self, m):
         # This test tests an impossible situation as `js` cannot be none. However, you never know.

--- a/tests/core/test_geodb_group_functions.py
+++ b/tests/core/test_geodb_group_functions.py
@@ -2,67 +2,67 @@ import unittest
 
 import requests_mock
 
-from tests.core.test_geodb import GeoDBClientTest
+from tests.core.geodb_test_base import GeoDBClientTestBase
 from xcube_geodb.core.geodb import GeoDBError
+from xcube_geodb.core.message import Message
 
 
 @requests_mock.mock(real_http=False)
 class GeoDBClientGroupsTest(unittest.TestCase):
-
     @classmethod
     def setUp(cls) -> None:
-        cls.base_test = GeoDBClientTest()
-        cls.base_test.setUp()
+        cls.test_base = GeoDBClientTestBase()
+        cls.test_base.setUp()
 
     def tearDown(self) -> None:
-        self.base_test.tearDown()
+        self.test_base.tearDown()
 
     def test_create_group(self, m):
-        self.base_test.set_global_mocks(m)
-        url = f"{self.base_test._base_url}/rpc/geodb_create_role"
+        self.test_base.set_global_mocks(m)
+        url = f"{self.test_base._base_url}/rpc/geodb_create_role"
         m.post(url, text="")
 
         usergroup = "test_group"
 
-        r = self.base_test._api.create_group(usergroup)
+        r = self.test_base._api.create_group(usergroup)
 
         expected = {"Message": f"Created new group {usergroup}."}
-        self.base_test.check_message(r, expected)
+        self._check_message(r, expected)
 
     def test_add_user_to_group(self, m):
-        self.base_test.set_global_mocks(m)
-        url = f"{self.base_test._base_url}/rpc/geodb_group_grant"
+        self.test_base.set_global_mocks(m)
+        url = f"{self.test_base._base_url}/rpc/geodb_group_grant"
         username = "test_user"
         usergroup = "test_group"
         m.post(url, text="")
 
-        r = self.base_test._api.add_user_to_group(username, usergroup)
+        r = self.test_base._api.add_user_to_group(username, usergroup)
 
         expected = {"Message": f"Added user {username} to {usergroup}"}
-        self.base_test.check_message(r, expected)
+        self._check_message(r, expected)
 
     def test_remove_user_from_group(self, m):
-        self.base_test.set_global_mocks(m)
-        url = f"{self.base_test._base_url}/rpc/geodb_group_revoke"
+        self.test_base.set_global_mocks(m)
+        url = f"{self.test_base._base_url}/rpc/geodb_group_revoke"
         m.post(url, text="")
 
         username = "test_user"
         usergroup = "test_group"
 
-        r = self.base_test._api.remove_user_from_group(username, usergroup)
+        r = self.test_base._api.remove_user_from_group(username, usergroup)
 
         expected = {"Message": f"Removed user {username} from {usergroup}"}
-        self.base_test.check_message(r, expected)
+        self._check_message(r, expected)
 
     def test_get_group_users(self, m):
-        self.base_test.set_global_mocks(m)
-        url = f"{self.base_test._base_url}/rpc/geodb_get_group_users"
+        self.test_base.set_global_mocks(m)
+        url = f"{self.test_base._base_url}/rpc/geodb_get_group_users"
         m.post(
             url,
             json=[
                 {
                     "res": [
-                        {"rolname": self.base_test._api.whoami},
+                        {"rolname": self.test_base._api.whoami},
                         {"rolname": "authenticator"},
                     ]
                 }
@@ -71,94 +71,94 @@ class GeoDBClientGroupsTest(unittest.TestCase):
 
         usergroup = "test_group"
 
-        r = self.base_test._api.get_group_users(usergroup)
-        self.assertListEqual(["authenticator", self.base_test._api.whoami], r)
+        r = self.test_base._api.get_group_users(usergroup)
+        self.assertListEqual(["authenticator", self.test_base._api.whoami], r)
 
     def test_publish_collection_to_group(self, m):
-        self.base_test.set_global_mocks(m)
-        url = f"{self.base_test._base_url}/rpc/geodb_group_publish_collection"
+        self.test_base.set_global_mocks(m)
+        url = f"{self.test_base._base_url}/rpc/geodb_group_publish_collection"
         m.post(url, text="")
-        url = f"{self.base_test._base_url}/rpc/geodb_user_allowed"
+        url = f"{self.test_base._base_url}/rpc/geodb_user_allowed"
         m.post(url, text="1")  # user is owner of database
 
         collection = "test_col"
         database = "test_db"
         group = "test_group"
 
-        r = self.base_test._api.publish_collection_to_group(collection, group, database)
+        r = self.test_base._api.publish_collection_to_group(collection, group, database)
 
         expected = {
             "Message": f"Published collection {collection} in "
             f"database {database} to group {group}."
         }
-        self.base_test.check_message(r, expected)
+        self._check_message(r, expected)
 
     def test_publish_database_to_group(self, m):
-        self.base_test.set_global_mocks(m)
+        self.test_base.set_global_mocks(m)
 
-        url = f'{self.base_test._base_url}/rpc/geodb_group_publish_database'
-        m.post(url, text='')
-        url = f'{self.base_test._base_url}/rpc/geodb_user_allowed'
-        m.post(url, text='1')  # user is owner of database
+        url = f"{self.test_base._base_url}/rpc/geodb_group_publish_database"
+        m.post(url, text="")
+        url = f"{self.test_base._base_url}/rpc/geodb_user_allowed"
+        m.post(url, text="1")  # user is owner of database
 
-        database = 'test_db'
-        group = 'test_group'
+        database = "test_db"
+        group = "test_group"
 
-        r = self.base_test._api.publish_database_to_group(group, database)
+        r = self.test_base._api.publish_database_to_group(group, database)
 
-        expected = {'Message': f'Published database {database} to group {group}.'}
-        self.base_test.check_message(r, expected)
+        expected = {"Message": f"Published database {database} to group {group}."}
+        self._check_message(r, expected)
 
-        url = f'{self.base_test._base_url}/rpc/geodb_user_allowed'
-        m.post(url, text='0')  # user is NOT owner of database
+        url = f"{self.test_base._base_url}/rpc/geodb_user_allowed"
+        m.post(url, text="0")  # user is NOT owner of database
         with self.assertRaises(GeoDBError):
-            self.base_test._api.publish_database_to_group(group, database)
+            self.test_base._api.publish_database_to_group(group, database)
 
     def test_unpublish_database_from_group(self, m):
-        self.base_test.set_global_mocks(m)
+        self.test_base.set_global_mocks(m)
 
-        url = f'{self.base_test._base_url}/rpc/geodb_group_unpublish_database'
-        m.post(url, text='')
-        url = f'{self.base_test._base_url}/rpc/geodb_user_allowed'
-        m.post(url, text='1')  # user is owner of database
+        url = f"{self.test_base._base_url}/rpc/geodb_group_unpublish_database"
+        m.post(url, text="")
+        url = f"{self.test_base._base_url}/rpc/geodb_user_allowed"
+        m.post(url, text="1")  # user is owner of database
 
-        database = 'test_db'
-        group = 'test_group'
+        database = "test_db"
+        group = "test_group"
 
-        r = self.base_test._api.unpublish_database_from_group(group, database)
+        r = self.test_base._api.unpublish_database_from_group(group, database)
 
-        expected = {'Message': f'Unpublished database {database} from group {group}.'}
-        self.base_test.check_message(r, expected)
+        expected = {"Message": f"Unpublished database {database} from group {group}."}
+        self._check_message(r, expected)
 
-        url = f'{self.base_test._base_url}/rpc/geodb_user_allowed'
-        m.post(url, text='0')  # user is NOT owner of database
+        url = f"{self.test_base._base_url}/rpc/geodb_user_allowed"
+        m.post(url, text="0")  # user is NOT owner of database
         with self.assertRaises(GeoDBError):
-            self.base_test._api.unpublish_database_from_group(group, database)
+            self.test_base._api.unpublish_database_from_group(group, database)
 
     def test_publish_collection_to_group_fails(self, m):
-        self.base_test.set_global_mocks(m)
-        url = f"{self.base_test._base_url}/rpc/geodb_group_publish_collection"
+        self.test_base.set_global_mocks(m)
+        url = f"{self.test_base._base_url}/rpc/geodb_group_publish_collection"
         m.post(url, text="")
-        url = f"{self.base_test._base_url}/rpc/geodb_user_allowed"
+        url = f"{self.test_base._base_url}/rpc/geodb_user_allowed"
         m.post(url, text="0")  # user is NOT owner of database
 
         with self.assertRaises(GeoDBError):
-            self.base_test._api.publish_collection_to_group(
+            self.test_base._api.publish_collection_to_group(
                 "collection", "group", "database"
             )
 
     def test_unpublish_collection_from_group(self, m):
-        self.base_test.set_global_mocks(m)
-        url = f"{self.base_test._base_url}/rpc/" f"geodb_group_unpublish_collection"
+        self.test_base.set_global_mocks(m)
+        url = f"{self.test_base._base_url}/rpc/geodb_group_unpublish_collection"
         m.post(url, text="")
-        url = f"{self.base_test._base_url}/rpc/geodb_user_allowed"
+        url = f"{self.test_base._base_url}/rpc/geodb_user_allowed"
         m.post(url, text="1")  # user is owner of database
 
         collection = "test_col"
         database = "test_db"
         group = "test_group"
 
-        r = self.base_test._api.unpublish_collection_from_group(
+        r = self.test_base._api.unpublish_collection_from_group(
             collection, group, database
         )
 
@@ -166,31 +166,31 @@ class GeoDBClientGroupsTest(unittest.TestCase):
             "Message": f"Unpublished collection {collection} in "
             f"database {database} from group {group}."
         }
-        self.base_test.check_message(r, expected)
+        self._check_message(r, expected)
 
     def test_get_my_groups(self, m):
-        self.base_test.set_global_mocks(m)
-        url = f"{self.base_test._base_url}/rpc/geodb_get_user_roles"
+        self.test_base.set_global_mocks(m)
+        url = f"{self.test_base._base_url}/rpc/geodb_get_user_roles"
         m.post(
             url,
             json=[
                 {
                     "src": [
-                        {"rolname": self.base_test._api.whoami},
+                        {"rolname": self.test_base._api.whoami},
                         {"rolname": "authenticator"},
                     ]
                 }
             ],
         )
 
-        roles = self.base_test._api.get_my_groups()
+        roles = self.test_base._api.get_my_groups()
         self.assertListEqual(["authenticator"], roles)
 
     def test_get_access_rights(self, m):
-        self.base_test.set_global_mocks(m)
-        url = f"{self.base_test._base_url}/rpc/geodb_get_grants"
+        self.test_base.set_global_mocks(m)
+        url = f"{self.test_base._base_url}/rpc/geodb_get_grants"
 
-        grantee = self.base_test._api.whoami
+        grantee = self.test_base._api.whoami
 
         m.post(
             url,
@@ -206,8 +206,12 @@ class GeoDBClientGroupsTest(unittest.TestCase):
             ],
         )
 
-        rights = self.base_test._api.get_access_rights("test_col_test_db")
+        rights = self.test_base._api.get_access_rights("test_col_test_db")
         self.assertDictEqual(
-            {self.base_test._api.whoami: ["INSERT", "SELECT", "UPDATE", "DELETE"]},
+            {self.test_base._api.whoami: ["INSERT", "SELECT", "UPDATE", "DELETE"]},
             rights,
         )
+
+    def _check_message(self, message, expected):
+        self.assertIsInstance(message, Message)
+        self.assertDictEqual(expected, message.to_dict())

--- a/tests/core/test_geodb_metadata_functions.py
+++ b/tests/core/test_geodb_metadata_functions.py
@@ -2,7 +2,7 @@ import unittest
 
 import requests_mock
 
-from tests.core.test_geodb import GeoDBClientTest
+from tests.core.geodb_test_base import GeoDBClientTestBase
 from xcube_geodb.core.error import GeoDBError
 from xcube_geodb.core.metadata import (
     Range,
@@ -17,7 +17,7 @@ from xcube_geodb.core.metadata import (
 class GeoDBClientMetadataTest(unittest.TestCase):
     @classmethod
     def setUp(cls) -> None:
-        cls.base_test = GeoDBClientTest()
+        cls.base_test = GeoDBClientTestBase()
         cls.base_test.setUp()
         cls.default_json = {
             "basic": {

--- a/tests/core/test_geodb_metadata_functions.py
+++ b/tests/core/test_geodb_metadata_functions.py
@@ -158,6 +158,20 @@ class GeoDBClientMetadataTest(unittest.TestCase):
         self.assertEqual(len(metadata.summaries), 4)
         self.assertEqual(len(metadata.item_assets), 1)
 
+        self.assertEqual(
+            "Sir Collection [my_test_collection]\n"
+            + "  Description: No description available\n"
+            + "  License: proprietary\n"
+            + "  Providers: I am a provider, I am another provider\n"
+            + "  Keywords: super, mega, awesome\n"
+            + "  Links: [{href = https://wurst.brot, rel = item, type = None, title = None, method = GET, headers = {'header-1': 'schnuffel', 'header-2': ['schnaffel', 'schnoffel']}, body = None}]\n"
+            + "  Assets: [{href = https://my-images.bc/image.png, description = some description, title = title of my image, type = None, roles = ['thumbnail', 'overview']}]\n"
+            + "  Item Assets: [{description = None, title = None, type = None, roles = None}]\n"
+            + "  Spatial extent: [[-180, -90, 0, 0], [-170, -80, -30, -20]]\n"
+            + "  Temporal extent: [['2019-01-01T00:00:00Z', None], ['2019-01-01T00:00:00Z', '2020-01-01T00:00:00Z']]",
+            str(metadata),
+        )
+
     def test_get_metadata_everything_none(self, m: requests_mock.mocker.Mocker):
         self.base_test.set_global_mocks(m)
         url = f"{self.base_test._base_url}/rpc/geodb_get_metadata"
@@ -193,6 +207,20 @@ class GeoDBClientMetadataTest(unittest.TestCase):
         self.assertListEqual(metadata.links, [])
         self.assertDictEqual(metadata.summaries, {})
         self.assertListEqual(metadata.item_assets, [])
+
+        self.assertEqual(
+            " [my_collection]\n"
+            + "  Description: No description available\n"
+            + "  License: proprietary\n"
+            + "  Providers: None\n"
+            + "  Keywords: None\n"
+            + "  Links: []\n"
+            + "  Assets: []\n"
+            + "  Item Assets: []\n"
+            + "  Spatial extent: [[-180, -90, 180, 90]]\n"
+            + "  Temporal extent: [[None, None]]",
+            str(metadata),
+        )
 
     def test_set_metadata_field(self, m: requests_mock.mocker.Mocker):
         self.base_test.set_global_mocks(m)

--- a/tests/core/test_geodb_metadata_functions.py
+++ b/tests/core/test_geodb_metadata_functions.py
@@ -1,0 +1,170 @@
+import unittest
+
+import requests_mock
+
+from tests.core.test_geodb import GeoDBClientTest
+from xcube_geodb.core.metadata import Range
+
+
+@requests_mock.mock(real_http=False)
+class GeoDBClientMetadataTest(unittest.TestCase):
+    @classmethod
+    def setUp(cls) -> None:
+        cls.base_test = GeoDBClientTest()
+        cls.base_test.setUp()
+        cls.default_json = {
+            "id": "3",
+            "links": [],
+            "spatial_extent": [[-180.0, -90.0, 180.0, 90.0]],
+            "temporal_extent": [[None, None]],
+            "description": "No description available",
+            "license": "proprietary",
+        }
+
+    def tearDown(self) -> None:
+        self.base_test.tearDown()
+
+    # noinspection PyTypeChecker
+    def test_get_metadata(self, m):
+        self.base_test.set_global_mocks(m)
+        url = f"{self.base_test._base_url}/rpc/geodb_get_metadata"
+        json = self.default_json
+        json["title"] = "Sir Collection"
+        json["providers"] = [
+            {
+                "name": "I am a provider",
+                "description": "This is my description",
+                "roles": ["licensor", "processor"],
+                "url": "https://xcube-dev.github.io/xcube-geodb/",
+            },
+            {
+                "name": "I am another provider",
+                "description": "This is my chorizo",
+                "roles": ["host"],
+            },
+        ]
+        json["assets"] = {
+            "asset_0": {
+                "href": "https://my-images.bc/image.png",
+                "title": "title of my image",
+                "description": "some description",
+                "roles": ["thumbnail", "overview"],
+            }
+        }
+        json["temporal_extent"] = [
+            ["2019-01-01T00:00:00Z", None],
+            ["2019-01-01T00:00:00Z", "2020-01-01T00:00:00Z"],
+        ]
+        json["spatial_extent"] = [
+            [-180, -90, 0, 0],
+            [-170, -80, -30, -20],
+        ]
+        json["stac_extensions"] = ["stac_ext_1", "stac_ext_2"]
+        json["keywords"] = ["super", "mega", "awesome"]
+        json["links"] = [
+            {
+                "href": "https://wurst.brot",
+                "rel": "item",
+                "type": None,
+                "title": None,
+                "method": "GET",
+                "headers": {
+                    "header-1": "schnuffel",
+                    "header-2": ["schnaffel", "schnoffel"],
+                },
+            }
+        ]
+        json["summaries"] = {
+            "column_names": ["temp", "height", "epoch"],
+            "temp_valid_range": Range(-10, 100),
+            "epoch_valid_range": Range("barocque", "modern"),
+            "schema": "json_schema_as_string",
+        }
+        m.post(
+            url,
+            json=json,
+        )
+
+        metadata = self.base_test._api.get_metadata(
+            collection="my_collection", database="database"
+        )
+        self.assertIsNotNone(metadata)
+        self.assertEqual(metadata.id, "3")
+        self.assertEqual(metadata.description, "No description available")
+        self.assertEqual(metadata.license, "proprietary")
+        self.assertEqual(metadata.type, "Collection")
+        self.assertEqual(metadata.title, "Sir Collection")
+        self.assertEqual(metadata.stac_version, "1.1.0")
+        self.assertEqual(metadata.stac_extensions, ["stac_ext_1", "stac_ext_2"])
+
+        self.assertEqual(len(metadata.providers), 2)
+        self.assertEqual(metadata.providers[0].name, "I am a provider")
+        self.assertEqual(metadata.providers[0].description, "This is my description")
+        self.assertEqual(metadata.providers[0].roles, ["licensor", "processor"])
+        self.assertEqual(
+            metadata.providers[0].url, "https://xcube-dev.github.io/xcube-geodb/"
+        )
+
+        self.assertEqual(len(metadata.assets), 1)
+        self.assertEqual(
+            metadata.assets["asset_0"].href, "https://my-images.bc/image.png"
+        )
+        self.assertEqual(metadata.assets["asset_0"].title, "title of my image")
+        self.assertEqual(metadata.assets["asset_0"].description, "some description")
+        self.assertEqual(metadata.assets["asset_0"].roles[0], "thumbnail")
+        self.assertEqual(metadata.assets["asset_0"].roles[1], "overview")
+        self.assertIsNone(metadata.assets["asset_0"].type)
+
+        self.assertEqual(
+            metadata.temporal_extent,
+            [
+                ["2019-01-01T00:00:00Z", None],
+                ["2019-01-01T00:00:00Z", "2020-01-01T00:00:00Z"],
+            ],
+        )
+        self.assertEqual(
+            metadata.spatial_extent,
+            [
+                [-180, -90, 0, 0],
+                [-170, -80, -30, -20],
+            ],
+        )
+        self.assertListEqual(metadata.keywords, ["super", "mega", "awesome"])
+        self.assertEqual(len(metadata.links), 1)
+        self.assertEqual(metadata.links[0].href, "https://wurst.brot")
+        self.assertEqual(metadata.links[0].method, "GET")
+        self.assertEqual(metadata.links[0].rel, "item")
+        self.assertIsNone(metadata.links[0].title)
+        self.assertDictEqual(
+            metadata.links[0].headers,
+            {
+                "header-1": "schnuffel",
+                "header-2": ["schnaffel", "schnoffel"],
+            },
+        )
+        self.assertEqual(len(metadata.summaries), 4)
+
+    def test_get_metadata_everything_none(self, m):
+        self.base_test.set_global_mocks(m)
+        url = f"{self.base_test._base_url}/rpc/geodb_get_metadata"
+        m.post(
+            url,
+            json=self.default_json,
+        )
+
+        metadata = self.base_test._api.get_metadata(
+            collection="my_collection", database="database"
+        )
+        self.assertEqual(len(metadata.providers), 0)
+        self.assertEqual(len(metadata.assets), 0)
+        self.assertEqual(len(metadata.temporal_extent), 1)
+        self.assertEqual(len(metadata.temporal_extent[0]), 2)
+        self.assertIsNone(metadata.temporal_extent[0][0])
+        self.assertIsNone(metadata.temporal_extent[0][1])
+        self.assertEqual(metadata.stac_extensions, [])
+        self.assertEqual(len(metadata.spatial_extent), 1)
+        self.assertListEqual(metadata.spatial_extent[0], [-180, -90, 180, 90])
+        self.assertIsNone(metadata.title)
+        self.assertListEqual(metadata.keywords, [])
+        self.assertListEqual(metadata.links, [])
+        self.assertDictEqual(metadata.summaries, {})

--- a/tests/core/test_message.py
+++ b/tests/core/test_message.py
@@ -5,7 +5,5 @@ from xcube_geodb.core.message import Message
 
 class TestMessage(unittest.TestCase):
     def test_message(self):
-        message = Message("BC-Staff ist durchaus klug")
-        self.assertDictEqual(
-            {"Message": "BC-Staff ist durchaus klug"}, message.to_dict()
-        )
+        message = Message("just a test message")
+        self.assertDictEqual({"Message": "just a test message"}, message.to_dict())

--- a/tests/sql/geodb_sql_test_base.py
+++ b/tests/sql/geodb_sql_test_base.py
@@ -1,0 +1,168 @@
+# The MIT License (MIT)
+# Copyright (c) 2025 by the xcube team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import datetime
+import os
+import sys
+import psycopg2
+import signal
+from time import sleep
+
+import xcube_geodb.version as version
+
+
+def get_app_dir():
+    import inspect
+
+    # noinspection PyTypeChecker
+    version_path = inspect.getfile(version)
+    return os.path.dirname(version_path)
+
+
+class GeoDBSqlTestBase:
+    _postgresql = None
+    _cursor = None
+    _conn = None
+
+    def ignored(self):
+        pass
+
+    @classmethod
+    def setUp(cls) -> None:
+        import psycopg2
+        import testing.postgresql
+
+        # for Windows, in case there are multiple installations of Postgres
+        # which makes psycopg find initdb like this:
+        # c:\path\to\installation-1\initdb.exe\r\nc:\path\to\installation-2\initdb.exe
+        # therefore, we split, and use the first installation that has "PostgreSQL" in its path
+        # because the PostGIS extension cannot be installed via conda nor pip in a compatible way
+
+        # Also, if you are using Docker Desktop for Windows, you have to do the
+        # following (only once, not everytime you are running the tests):
+        # dism.exe /Online /Disable-Feature:Microsoft-Hyper-V
+        # netsh int ipv4 add excludedportrange protocol=tcp startport=50777 numberofports=1
+        # dism.exe /Online /Enable-Feature:Microsoft-Hyper-V /All
+        #
+        # (copied from
+        # https://github.com/docker/for-win/issues/3171#issuecomment-459205576)
+
+        def find_program(name: str) -> str:
+            program = testing.postgresql.find_program(name, [])
+            return program.split("\r\n")[0]
+
+        if os.name == "nt":
+            path = os.environ["PATH"].split(os.pathsep)
+            dirs = [directory for directory in path if "PostgreSQL" in directory]
+            dirs.extend(
+                [directory for directory in path if "PostgreSQL" not in directory]
+            )
+            os.environ["PATH"] = os.pathsep.join(dirs)
+
+        initdb = find_program("initdb")
+        postgres = find_program("postgres")
+
+        # special windows treatment end
+
+        postgresql = testing.postgresql.PostgresqlFactory(
+            cache_initialized_db=False,
+            initdb=initdb,
+            postgres=postgres,
+            port=50777,
+        )
+
+        cls._postgresql = postgresql()
+        dsn = cls._postgresql.dsn()
+        if sys.platform == "win32":
+            dsn["port"] = 50777
+            dsn["password"] = "postgres"
+        cls._conn = psycopg2.connect(**dsn)
+        cls._cursor = cls._conn.cursor()
+        app_path = get_app_dir()
+        fn = os.path.join(app_path, "sql", "geodb.sql")
+        with open(fn) as sql_file:
+            sql_content = sql_file.read()
+            sql_content = sql_content.replace("VERSION_PLACEHOLDER", version.version)
+            cls._cursor.execute(sql_content)
+
+        fn = os.path.join(app_path, "..", "tests", "sql", "setup.sql")
+        with open(fn) as sql_file:
+            cls._cursor.execute(sql_file.read())
+        cls._conn.commit()
+
+    def tearDown(self) -> None:
+        if sys.platform == "win32":
+            self.manual_cleanup()
+        else:
+            self._postgresql.stop()
+
+    def manual_cleanup(self):
+        import shutil
+
+        try:
+            self._conn.close()
+            dsn = self._postgresql.dsn()
+            dsn["port"] = 50777
+            dsn["password"] = "postgres"
+            dsn["database"] = "postgres"
+            self._conn = psycopg2.connect(**dsn)
+            self._conn.autocommit = True
+            self._cursor = self._conn.cursor()
+            self._cursor.execute("drop database test;")
+            self._cursor.execute("create database test;")
+            self.set_role("postgres")
+            self._cursor.execute(
+                "DROP ROLE IF EXISTS geodb_user ; "
+                "DROP ROLE IF EXISTS geodb_user_read_only ; "
+                'DROP ROLE IF EXISTS "geodb_user-with-hyphens" ; '
+                "DROP ROLE IF EXISTS test_group ; "
+                "DROP ROLE IF EXISTS new_group ; "
+                "DROP ROLE IF EXISTS test_admin ; "
+                "DROP ROLE IF EXISTS test_noadmin ; "
+                "DROP ROLE IF EXISTS test_member ; "
+                "DROP ROLE IF EXISTS test_member_2 ; "
+                "DROP ROLE IF EXISTS test_nomember ;"
+                "DROP ROLE IF EXISTS some_group ;"
+            )
+            self._conn.commit()
+            self._conn.close()
+            self._postgresql.child_process.send_signal(signal.CTRL_BREAK_EVENT)
+            killed_at = datetime.datetime.now()
+            while self._postgresql.child_process.poll() is None:
+                if (datetime.datetime.now() - killed_at).seconds > 10.0:
+                    self._postgresql.child_process.kill()
+                    raise RuntimeError(
+                        "*** failed to shutdown postgres (timeout) ***\n"
+                    )
+
+                sleep(0.1)
+
+        except OSError as e:
+            raise e
+        shutil.rmtree(self._postgresql.base_dir, ignore_errors=True)
+
+    def tearDownModule(self):
+        # clear cached database at end of tests
+        self._postgresql.clear_cache()
+
+    def set_role(self, user_name: str):
+        sql = f'SET LOCAL ROLE "{user_name}"'
+        self._cursor.execute(sql)

--- a/tests/sql/setup-metadata.sql
+++ b/tests/sql/setup-metadata.sql
@@ -38,11 +38,11 @@ VALUES ('another_provider', 'i am an ok provider!', ARRAY ['producer'::geodb_col
         'https://ok-provider.com',
         'land_use', 'geodb_user');
 
-INSERT INTO geodb_collection_metadata.asset("name", "href", "collection_name", "database")
-VALUES ('some_asset', 'https://best-assets.bc', 'land_use', 'geodb_user');
+INSERT INTO geodb_collection_metadata.asset("href", "collection_name", "database")
+VALUES ('https://best-assets.bc', 'land_use', 'geodb_user');
 
-INSERT INTO geodb_collection_metadata."item_asset"("name", "type", "collection_name", "database")
-VALUES ('some_item_asset', 'I have a type', 'land_use', 'geodb_user');
+INSERT INTO geodb_collection_metadata."item_asset"("type", "collection_name", "database")
+VALUES ('I have a type', 'land_use', 'geodb_user');
 
 INSERT INTO geodb_collection_metadata.basic ("collection_name", "database", "title")
 VALUES ('some_other_collection', 'some_database', 'I am some other collection');

--- a/tests/sql/setup-metadata.sql
+++ b/tests/sql/setup-metadata.sql
@@ -1,0 +1,48 @@
+INSERT INTO geodb_collection_metadata.metadata ("collection_name", "title", "description", "spatial_extent",
+                                                "keywords", "summaries")
+VALUES ('geodb_user_land_use', 'Land Use',
+        'Sample table',
+        ARRAY [ST_GeomFromText('POLYGON((-170 -80, -170 80, 170 80, -170 -80, -170 -80))'), ST_GeomFromText('POLYGON((-169 -79, -169 79, 169 79, -169 -79, -169 -79))')],
+        ARRAY ['land', 'use'],
+        '{
+          "columns": [
+            "id",
+            "geometry"
+          ],
+          "x_range": {
+            "min": "-170",
+            "max": "170"
+          },
+          "y_range": {
+            "min": "-80",
+            "max": "80"
+          },
+          "schema": "this is a complex schema stored in a string"
+        }'::JSONB);
+
+INSERT INTO geodb_collection_metadata.link("href", "rel", "title", "collection_name")
+VALUES ('https://something.sth', 'self', 'some_link', 'geodb_user_land_use');
+
+INSERT INTO geodb_collection_metadata.link("href", "rel", "title", "collection_name")
+VALUES ('https://something.else', 'root', 'some_other_link', 'geodb_user_land_use');
+
+INSERT INTO geodb_collection_metadata.provider("name", "description", "url", "collection_name")
+VALUES ('some_provider', 'i am the best provider!', 'https://best-provider.com', 'geodb_user_land_use');
+
+INSERT INTO geodb_collection_metadata.provider("name", "description", "url", "collection_name")
+VALUES ('some_other_provider', 'i am the worst provider!', 'https://worst-provider.com', 'geodb_user_land_use');
+
+INSERT INTO geodb_collection_metadata.provider("name", "description", "roles", "url", "collection_name")
+VALUES ('another_provider', 'i am an ok provider!', ARRAY ['producer'::geodb_collection_metadata.provider_role,
+    'host'::geodb_collection_metadata.provider_role],
+        'https://ok-provider.com',
+        'geodb_user_land_use');
+
+INSERT INTO geodb_collection_metadata.asset("name", "href", "collection_name")
+VALUES ('some_asset', 'https://best-assets.bc', 'geodb_user_land_use');
+
+INSERT INTO geodb_collection_metadata."item_asset"("name", "type", "collection_name")
+VALUES ('some_item_asset', 'I have a type', 'geodb_user_land_use');
+
+INSERT INTO geodb_collection_metadata.metadata ("collection_name", "title")
+VALUES ('some_other_collection', 'I am something else');

--- a/tests/sql/setup-metadata.sql
+++ b/tests/sql/setup-metadata.sql
@@ -1,6 +1,6 @@
-INSERT INTO geodb_collection_metadata.metadata ("collection_name", "title", "description", "spatial_extent",
-                                                "keywords", "summaries")
-VALUES ('geodb_user_land_use', 'Land Use',
+INSERT INTO geodb_collection_metadata.basic ("collection_name", "database", "title", "description", "spatial_extent",
+                                             "keywords", "summaries")
+VALUES ('land_use', 'geodb_user', 'Land Use',
         'Sample table',
         ARRAY [ST_GeomFromText('POLYGON((-170 -80, -170 80, 170 80, -170 -80, -170 -80))'), ST_GeomFromText('POLYGON((-169 -79, -169 79, 169 79, -169 -79, -169 -79))')],
         ARRAY ['land', 'use'],
@@ -20,29 +20,29 @@ VALUES ('geodb_user_land_use', 'Land Use',
           "schema": "this is a complex schema stored in a string"
         }'::JSONB);
 
-INSERT INTO geodb_collection_metadata.link("href", "rel", "title", "collection_name")
-VALUES ('https://something.sth', 'self', 'some_link', 'geodb_user_land_use');
+INSERT INTO geodb_collection_metadata.link("href", "rel", "title", "collection_name", "database")
+VALUES ('https://something.sth', 'self', 'some_link', 'land_use', 'geodb_user');
 
-INSERT INTO geodb_collection_metadata.link("href", "rel", "title", "collection_name")
-VALUES ('https://something.else', 'root', 'some_other_link', 'geodb_user_land_use');
+INSERT INTO geodb_collection_metadata.link("href", "rel", "title", "collection_name", "database")
+VALUES ('https://something.else', 'root', 'some_other_link', 'land_use', 'geodb_user');
 
-INSERT INTO geodb_collection_metadata.provider("name", "description", "url", "collection_name")
-VALUES ('some_provider', 'i am the best provider!', 'https://best-provider.com', 'geodb_user_land_use');
+INSERT INTO geodb_collection_metadata.provider("name", "description", "url", "collection_name", "database")
+VALUES ('some_provider', 'i am the best provider!', 'https://best-provider.com', 'land_use', 'geodb_user');
 
-INSERT INTO geodb_collection_metadata.provider("name", "description", "url", "collection_name")
-VALUES ('some_other_provider', 'i am the worst provider!', 'https://worst-provider.com', 'geodb_user_land_use');
+INSERT INTO geodb_collection_metadata.provider("name", "description", "url", "collection_name", "database")
+VALUES ('some_other_provider', 'i am the worst provider!', 'https://worst-provider.com', 'land_use', 'geodb_user');
 
-INSERT INTO geodb_collection_metadata.provider("name", "description", "roles", "url", "collection_name")
+INSERT INTO geodb_collection_metadata.provider("name", "description", "roles", "url", "collection_name", "database")
 VALUES ('another_provider', 'i am an ok provider!', ARRAY ['producer'::geodb_collection_metadata.provider_role,
     'host'::geodb_collection_metadata.provider_role],
         'https://ok-provider.com',
-        'geodb_user_land_use');
+        'land_use', 'geodb_user');
 
-INSERT INTO geodb_collection_metadata.asset("name", "href", "collection_name")
-VALUES ('some_asset', 'https://best-assets.bc', 'geodb_user_land_use');
+INSERT INTO geodb_collection_metadata.asset("name", "href", "collection_name", "database")
+VALUES ('some_asset', 'https://best-assets.bc', 'land_use', 'geodb_user');
 
-INSERT INTO geodb_collection_metadata."item_asset"("name", "type", "collection_name")
-VALUES ('some_item_asset', 'I have a type', 'geodb_user_land_use');
+INSERT INTO geodb_collection_metadata."item_asset"("name", "type", "collection_name", "database")
+VALUES ('some_item_asset', 'I have a type', 'land_use', 'geodb_user');
 
-INSERT INTO geodb_collection_metadata.metadata ("collection_name", "title")
-VALUES ('some_other_collection', 'I am some other collection');
+INSERT INTO geodb_collection_metadata.basic ("collection_name", "database", "title")
+VALUES ('some_other_collection', 'some_database', 'I am some other collection');

--- a/tests/sql/setup-metadata.sql
+++ b/tests/sql/setup-metadata.sql
@@ -45,4 +45,4 @@ INSERT INTO geodb_collection_metadata."item_asset"("name", "type", "collection_n
 VALUES ('some_item_asset', 'I have a type', 'geodb_user_land_use');
 
 INSERT INTO geodb_collection_metadata.metadata ("collection_name", "title")
-VALUES ('some_other_collection', 'I am something else');
+VALUES ('some_other_collection', 'I am some other collection');

--- a/tests/sql/test_sql_functions.py
+++ b/tests/sql/test_sql_functions.py
@@ -84,11 +84,16 @@ class GeoDBSqlTest(unittest.TestCase):
 
         # special windows treatment end
 
+        tmpdir = os.path.join(os.getcwd(), "tmp")
+        os.makedirs(tmpdir, exist_ok=True)
+
         postgresql = testing.postgresql.PostgresqlFactory(
             cache_initialized_db=False,
             initdb=initdb,
             postgres=postgres,
             port=50777,
+            base_dir=tmpdir,
+            postgres_args="-h 127.0.0.1 -F -c logging_collector=on -c log_statement=all -c log_min_messages=debug3 -c client_min_messages=debug3 -c log_destination=stderr",
         )
 
         cls._postgresql = postgresql()

--- a/tests/sql/test_sql_functions.py
+++ b/tests/sql/test_sql_functions.py
@@ -84,16 +84,11 @@ class GeoDBSqlTest(unittest.TestCase):
 
         # special windows treatment end
 
-        tmpdir = os.path.join(os.getcwd(), "tmp")
-        os.makedirs(tmpdir, exist_ok=True)
-
         postgresql = testing.postgresql.PostgresqlFactory(
             cache_initialized_db=False,
             initdb=initdb,
             postgres=postgres,
             port=50777,
-            base_dir=tmpdir,
-            postgres_args="-h 127.0.0.1 -F -c logging_collector=on -c log_statement=all -c log_min_messages=debug3 -c client_min_messages=debug3 -c log_destination=stderr",
         )
 
         cls._postgresql = postgresql()

--- a/tests/sql/test_sql_functions.py
+++ b/tests/sql/test_sql_functions.py
@@ -1,3 +1,24 @@
+# The MIT License (MIT)
+# Copyright (c) 2025 by the xcube team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
 import datetime
 import os
 import sys

--- a/tests/sql/test_sql_functions.py
+++ b/tests/sql/test_sql_functions.py
@@ -21,149 +21,27 @@
 
 import datetime
 import os
-import sys
 import unittest
 import json
 import psycopg2
-import signal
-from time import sleep
 
 import xcube_geodb.version as version
+from tests.sql.geodb_sql_test_base import GeoDBSqlTestBase
 from xcube_geodb.core.geodb import EventType
 
 
-def get_app_dir():
-    import inspect
-
-    # noinspection PyTypeChecker
-    version_path = inspect.getfile(version)
-    return os.path.dirname(version_path)
-
-
-# noinspection SqlInjection,SqlNoDataSourceInspection,SqlResolve
 @unittest.skipIf(os.environ.get("SKIP_PSQL_TESTS", "0") == "1", "DB Tests skipped")
-class GeoDBSqlTest(unittest.TestCase):
-    _postgresql = None
-    _cursor = None
-    _conn = None
-
+class GeoDBSqlBaseTest(unittest.TestCase):
     @classmethod
     def setUp(cls) -> None:
-        import psycopg2
-        import testing.postgresql
-
-        # for Windows, in case there are multiple installations of Postgres
-        # which makes psycopg find initdb like this:
-        # c:\path\to\installation-1\initdb.exe\r\nc:\path\to\installation-2\initdb.exe
-        # therefore, we split, and use the first installation that has "PostgreSQL" in its path
-        # because the PostGIS extension cannot be installed via conda nor pip in a compatible way
-
-        # Also, if you are using Docker Desktop for Windows, you have to do the
-        # following (only once, not everytime you are running the tests):
-        # dism.exe /Online /Disable-Feature:Microsoft-Hyper-V
-        # netsh int ipv4 add excludedportrange protocol=tcp startport=50777 numberofports=1
-        # dism.exe /Online /Enable-Feature:Microsoft-Hyper-V /All
-        #
-        # (copied from
-        # https://github.com/docker/for-win/issues/3171#issuecomment-459205576)
-
-        def find_program(name: str) -> str:
-            program = testing.postgresql.find_program(name, [])
-            return program.split("\r\n")[0]
-
-        if os.name == "nt":
-            path = os.environ["PATH"].split(os.pathsep)
-            dirs = [directory for directory in path if "PostgreSQL" in directory]
-            dirs.extend(
-                [directory for directory in path if "PostgreSQL" not in directory]
-            )
-            os.environ["PATH"] = os.pathsep.join(dirs)
-
-        initdb = find_program("initdb")
-        postgres = find_program("postgres")
-
-        # special windows treatment end
-
-        postgresql = testing.postgresql.PostgresqlFactory(
-            cache_initialized_db=False,
-            initdb=initdb,
-            postgres=postgres,
-            port=50777,
-        )
-
-        cls._postgresql = postgresql()
-        dsn = cls._postgresql.dsn()
-        if sys.platform == "win32":
-            dsn["port"] = 50777
-            dsn["password"] = "postgres"
-        cls._conn = psycopg2.connect(**dsn)
-        cls._cursor = cls._conn.cursor()
-        app_path = get_app_dir()
-        fn = os.path.join(app_path, "sql", "geodb.sql")
-        with open(fn) as sql_file:
-            sql_content = sql_file.read()
-            sql_content = sql_content.replace("VERSION_PLACEHOLDER", version.version)
-            cls._cursor.execute(sql_content)
-
-        fn = os.path.join(app_path, "..", "tests", "sql", "setup.sql")
-        with open(fn) as sql_file:
-            cls._cursor.execute(sql_file.read())
-        cls._conn.commit()
+        cls.base_test = GeoDBSqlTestBase()
+        cls.base_test.setUp()
+        cls._cursor = cls.base_test._cursor
+        cls._set_role = cls.base_test.set_role
+        cls._conn = cls.base_test._conn
 
     def tearDown(self) -> None:
-        if sys.platform == "win32":
-            self.manual_cleanup()
-        else:
-            self._postgresql.stop()
-
-    def manual_cleanup(self):
-        import shutil
-
-        try:
-            self._conn.close()
-            dsn = self._postgresql.dsn()
-            dsn["port"] = 50777
-            dsn["password"] = "postgres"
-            dsn["database"] = "postgres"
-            self._conn = psycopg2.connect(**dsn)
-            self._conn.autocommit = True
-            self._cursor = self._conn.cursor()
-            self._cursor.execute("drop database test;")
-            self._cursor.execute("create database test;")
-            self._set_role("postgres")
-            self._cursor.execute(
-                "DROP ROLE IF EXISTS geodb_user ; "
-                "DROP ROLE IF EXISTS geodb_user_read_only ; "
-                'DROP ROLE IF EXISTS "geodb_user-with-hyphens" ; '
-                "DROP ROLE IF EXISTS test_group ; "
-                "DROP ROLE IF EXISTS new_group ; "
-                "DROP ROLE IF EXISTS test_admin ; "
-                "DROP ROLE IF EXISTS test_noadmin ; "
-                "DROP ROLE IF EXISTS test_member ; "
-                "DROP ROLE IF EXISTS test_member_2 ; "
-                "DROP ROLE IF EXISTS test_nomember ;"
-                "DROP ROLE IF EXISTS some_group ;"
-            )
-            self._conn.commit()
-            self._conn.close()
-            self._postgresql.child_process.send_signal(signal.CTRL_BREAK_EVENT)
-            killed_at = datetime.datetime.now()
-            while self._postgresql.child_process.poll() is None:
-                if (datetime.datetime.now() - killed_at).seconds > 10.0:
-                    self._postgresql.child_process.kill()
-                    raise RuntimeError(
-                        "*** failed to shutdown postgres (timeout) ***\n"
-                    )
-
-                sleep(0.1)
-
-        except OSError as e:
-            raise e
-        shutil.rmtree(self._postgresql.base_dir, ignore_errors=True)
-
-    def tearDownModule(self):
-        # clear cached database at end of tests
-        self._postgresql.clear_cache()
+        self.base_test.tearDown()
 
     def test_query_by_bbox(self):
         sql_filter = (
@@ -235,10 +113,6 @@ class GeoDBSqlTest(unittest.TestCase):
         self._cursor.execute(sql)
         return self._cursor.fetchone()[0]
 
-    def _set_role(self, user_name: str):
-        sql = f'SET LOCAL ROLE "{user_name}"'
-        self._cursor.execute(sql)
-
     def test_manage_table(self):
         user_name = "geodb_user"
         user_table = user_name + "_test"
@@ -256,12 +130,12 @@ class GeoDBSqlTest(unittest.TestCase):
         self.assertTrue(self.column_exists(user_table, "id", "integer"))
         self.assertTrue(self.column_exists(user_table, "geometry", "USER-DEFINED"))
 
-        datasets = {
+        collections = {
             "geodb_user_tt1": {"crs": "4326", "properties": {"tt": "integer"}},
             "geodb_user_tt2": {"crs": "4326", "properties": {"tt": "integer"}},
         }
 
-        sql = f"SELECT geodb_create_collections('{json.dumps(datasets)}')"
+        sql = f"SELECT geodb_create_collections('{json.dumps(collections)}')"
         self._cursor.execute(sql)
 
         self.assertTrue(self.table_exists(user_table))
@@ -269,8 +143,8 @@ class GeoDBSqlTest(unittest.TestCase):
         self.assertTrue(self.column_exists(user_table, "id", "integer"))
         self.assertTrue(self.column_exists(user_table, "geometry", "USER-DEFINED"))
 
-        datasets = ["geodb_user_test", "geodb_user_tt1", "geodb_user_tt2"]
-        sql = f"SELECT geodb_drop_collections('{json.dumps(datasets)}')"
+        collection_names = ["test", "tt1", "tt2"]
+        sql = f"SELECT geodb_drop_collections('geodb_user', '{json.dumps(collection_names)}')"
         self._cursor.execute(sql)
         self.assertFalse(self.table_exists(user_table))
 

--- a/tests/sql/test_sql_group_functions.py
+++ b/tests/sql/test_sql_group_functions.py
@@ -1,3 +1,24 @@
+# The MIT License (MIT)
+# Copyright (c) 2025 by the xcube team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
 import json
 import os
 import unittest
@@ -10,7 +31,6 @@ from tests.sql.test_sql_functions import get_app_dir
 
 
 class GeoDBSQLGroupTest(unittest.TestCase):
-
     @classmethod
     def setUp(cls) -> None:
         cls.base_test = GeoDBSqlTest()
@@ -185,14 +205,18 @@ class GeoDBSQLGroupTest(unittest.TestCase):
 
     def publish_database_to_group(self, user):
         self._set_role(user)
-        sql = f"SELECT geodb_group_publish_database('{self.database_name}'," \
-              f"'{self.test_group}')"
+        sql = (
+            f"SELECT geodb_group_publish_database('{self.database_name}',"
+            f"'{self.test_group}')"
+        )
         self.execute(sql)
 
     def unpublish_database_from_group(self, user):
         self._set_role(user)
-        sql = f"SELECT geodb_group_unpublish_database('{self.database_name}'," \
-              f"'{self.test_group}')"
+        sql = (
+            f"SELECT geodb_group_unpublish_database('{self.database_name}',"
+            f"'{self.test_group}')"
+        )
         self.execute(sql)
 
     def access_table_with_user_fail(self, user):
@@ -223,16 +247,19 @@ class GeoDBSQLGroupTest(unittest.TestCase):
     def create_table_as_user(self, user, table_name):
         self._set_role(user)
         props = {}
-        sql = f"SELECT geodb_create_collection('{table_name}', " \
-              f"'{json.dumps(props)}', '4326')"
+        sql = (
+            f"SELECT geodb_create_collection('{table_name}', "
+            f"'{json.dumps(props)}', '4326')"
+        )
         self.execute(sql)
-
 
     def create_table_as_user_fails(self, user, table_name):
         self._set_role(user)
         props = {}
-        sql = f"SELECT geodb_create_collection('{table_name}', " \
-              f"'{json.dumps(props)}', '4326')"
+        sql = (
+            f"SELECT geodb_create_collection('{table_name}', "
+            f"'{json.dumps(props)}', '4326')"
+        )
         with self.assertRaises(psycopg2.errors.RaiseException):
             self.execute(sql)
         # necessary so we can keep using the connection after the failed query

--- a/tests/sql/test_sql_group_functions.py
+++ b/tests/sql/test_sql_group_functions.py
@@ -26,17 +26,16 @@ import unittest
 import pandas as pd
 import psycopg2
 
-from tests.sql.test_sql_functions import GeoDBSqlTest
-from tests.sql.test_sql_functions import get_app_dir
+from tests.sql.geodb_sql_test_base import GeoDBSqlTestBase, get_app_dir
 
 
 class GeoDBSQLGroupTest(unittest.TestCase):
     @classmethod
     def setUp(cls) -> None:
-        cls.base_test = GeoDBSqlTest()
+        cls.base_test = GeoDBSqlTestBase()
         cls.base_test.setUp()
         cls._cursor = cls.base_test._cursor
-        cls._set_role = cls.base_test._set_role
+        cls._set_role = cls.base_test.set_role
         cls._conn = cls.base_test._conn
 
         app_path = get_app_dir()

--- a/tests/sql/test_sql_metadata_functions.py
+++ b/tests/sql/test_sql_metadata_functions.py
@@ -25,8 +25,8 @@ from unittest.mock import patch
 
 from psycopg2.errors import RaiseException
 
-from tests.sql.test_sql_functions import GeoDBSqlTest
-from tests.sql.test_sql_functions import get_app_dir
+from tests.sql.geodb_sql_test_base import get_app_dir
+from tests.sql.test_sql_functions import GeoDBSqlTestBase
 from xcube_geodb.core.db_interface import DbInterface
 from xcube_geodb.core.geodb import GeoDBClient
 from xcube_geodb.core.metadata import MetadataManager, Metadata
@@ -35,10 +35,10 @@ from xcube_geodb.core.metadata import MetadataManager, Metadata
 class GeoDBSQLMDTest(unittest.TestCase):
     @classmethod
     def setUp(cls) -> None:
-        cls.base_test = GeoDBSqlTest()
+        cls.base_test = GeoDBSqlTestBase()
         cls.base_test.setUp()
         cls._cursor = cls.base_test._cursor
-        cls._set_role = cls.base_test._set_role
+        cls._set_role = cls.base_test.set_role
         cls._conn = cls.base_test._conn
 
         app_path = get_app_dir()
@@ -121,17 +121,17 @@ class GeoDBSQLMDTest(unittest.TestCase):
         result = self._cursor.fetchall()
         self.assertEqual(3, len(result))
 
-        self.assertEqual("some_provider", result[0][0])
-        self.assertEqual("some_other_provider", result[1][0])
-        self.assertEqual("another_provider", result[2][0])
+        self.assertEqual("some_provider", result[0][1])
+        self.assertEqual("some_other_provider", result[1][1])
+        self.assertEqual("another_provider", result[2][1])
 
-        self.assertEqual("i am the best provider!", result[0][1])
-        self.assertEqual("i am the worst provider!", result[1][1])
-        self.assertEqual("i am an ok provider!", result[2][1])
+        self.assertEqual("i am the best provider!", result[0][2])
+        self.assertEqual("i am the worst provider!", result[1][2])
+        self.assertEqual("i am an ok provider!", result[2][2])
 
-        self.assertEqual("{}", result[0][2])
-        self.assertEqual("{}", result[1][2])
-        self.assertEqual("{producer,host}", result[2][2])
+        self.assertEqual("{}", result[0][3])
+        self.assertEqual("{}", result[1][3])
+        self.assertEqual("{producer,host}", result[2][3])
 
         sql = "SELECT * from geodb_collection_metadata.asset;"
         self._cursor.execute(sql)

--- a/tests/sql/test_sql_metadata_functions.py
+++ b/tests/sql/test_sql_metadata_functions.py
@@ -1,0 +1,180 @@
+# The MIT License (MIT)
+# Copyright (c) 2025 by the xcube team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+import os
+import unittest
+
+from tests.sql.test_sql_functions import GeoDBSqlTest
+from tests.sql.test_sql_functions import get_app_dir
+from xcube_geodb.core.metadata import Metadata
+
+
+class GeoDBSQLMDTest(unittest.TestCase):
+    @classmethod
+    def setUp(cls) -> None:
+        cls.base_test = GeoDBSqlTest()
+        cls.base_test.setUp()
+        cls._cursor = cls.base_test._cursor
+        cls._set_role = cls.base_test._set_role
+        cls._conn = cls.base_test._conn
+
+        app_path = get_app_dir()
+        fn = os.path.join(app_path, "..", "tests", "sql", "setup-metadata.sql")
+        with open(fn) as sql_file:
+            cls.base_test._cursor.execute(sql_file.read())
+
+        cls._conn.commit()
+
+    def tearDown(self) -> None:
+        self.base_test.tearDown()
+
+    def test_metadata_table_initialisation(self):
+        sql = 'SELECT "collection_name" from geodb_collection_metadata.metadata;'
+        self._cursor.execute(sql)
+        self.assertEqual("geodb_user_land_use", self._cursor.fetchone()[0])
+
+        sql = 'SELECT "title" from geodb_collection_metadata.metadata;'
+        self._cursor.execute(sql)
+        self.assertEqual("Land Use", self._cursor.fetchone()[0])
+
+        sql = 'SELECT "description" from geodb_collection_metadata.metadata;'
+        self._cursor.execute(sql)
+        self.assertEqual("Sample table", self._cursor.fetchone()[0])
+
+        sql = 'SELECT "license" from geodb_collection_metadata.metadata;'
+        self._cursor.execute(sql)
+        self.assertEqual("proprietary", self._cursor.fetchone()[0])
+
+        sql = 'SELECT "spatial_extent" from geodb_collection_metadata.metadata;'
+        self._cursor.execute(sql)
+        geometries = [
+            item.strip("{}") for item in self._cursor.fetchone()[0].split(",") if item
+        ]
+        sql = f"SELECT ST_ASTEXT('{geometries[0].split(':')[0]}');"
+        self._cursor.execute(sql)
+        self.assertEqual(
+            "POLYGON((-170 -80,-170 80,170 80,-170 -80,-170 -80))",
+            self._cursor.fetchone()[0],
+        )
+
+        sql = 'SELECT "temporal_extent" from geodb_collection_metadata.metadata;'
+        self._cursor.execute(sql)
+        self.assertEqual([[None, None]], self._cursor.fetchone()[0])
+
+        sql = 'SELECT "stac_extensions" from geodb_collection_metadata.metadata;'
+        self._cursor.execute(sql)
+        self.assertEqual([], self._cursor.fetchone()[0])
+
+        sql = 'SELECT "keywords" from geodb_collection_metadata.metadata;'
+        self._cursor.execute(sql)
+        self.assertEqual(["land", "use"], self._cursor.fetchone()[0])
+
+        sql = 'SELECT "summaries" from geodb_collection_metadata.metadata;'
+        self._cursor.execute(sql)
+        self.assertEqual(
+            {
+                "columns": ["id", "geometry"],
+                "schema": "this is a complex schema stored in a string",
+                "x_range": {"max": "170", "min": "-170"},
+                "y_range": {"max": "80", "min": "-80"},
+            },
+            self._cursor.fetchone()[0],
+        )
+
+        sql = "SELECT * from geodb_collection_metadata.link;"
+        self._cursor.execute(sql)
+        result = self._cursor.fetchall()
+        self.assertEqual(2, len(result))
+
+        self.assertEqual("some_link", result[0][4])
+        self.assertEqual("some_other_link", result[1][4])
+
+        sql = "SELECT * from geodb_collection_metadata.provider;"
+        self._cursor.execute(sql)
+        result = self._cursor.fetchall()
+        self.assertEqual(3, len(result))
+
+        self.assertEqual("some_provider", result[0][0])
+        self.assertEqual("some_other_provider", result[1][0])
+        self.assertEqual("another_provider", result[2][0])
+
+        self.assertEqual("i am the best provider!", result[0][1])
+        self.assertEqual("i am the worst provider!", result[1][1])
+        self.assertEqual("i am an ok provider!", result[2][1])
+
+        self.assertEqual("{}", result[0][2])
+        self.assertEqual("{}", result[1][2])
+        self.assertEqual("{producer,host}", result[2][2])
+
+        sql = "SELECT * from geodb_collection_metadata.asset;"
+        self._cursor.execute(sql)
+        result = self._cursor.fetchall()
+        self.assertEqual(1, len(result))
+
+        self.assertEqual("some_asset", result[0][0])
+        self.assertEqual("https://best-assets.bc", result[0][1])
+        self.assertEqual([], result[0][5])
+
+        sql = 'SELECT * from geodb_collection_metadata."item_asset";'
+        self._cursor.execute(sql)
+        result = self._cursor.fetchall()
+        self.assertEqual(1, len(result))
+
+        self.assertEqual("some_item_asset", result[0][0])
+        self.assertEqual("I have a type", result[0][3])
+        self.assertEqual([], result[0][4])
+
+    def test_get_metadata(self):
+        sql = "SELECT geodb_get_metadata('geodb_user_land_use')"
+        self._cursor.execute(sql)
+        result = self._cursor.fetchone()[0]
+        md = Metadata.from_json(result)
+        self.assertEqual("geodb_user_land_use", md.id)
+        self.assertEqual("Land Use", md.title)
+        self.assertEqual("proprietary", md.license)
+        self.assertEqual("Sample table", md.description)
+        self.assertEqual(
+            [[-170, -80, 170, 80], [-169, -79, 169, 79]],
+            md.spatial_extent,
+        )
+        self.assertEqual([[None, None]], md.temporal_extent)
+        self.assertEqual(1, len(md.assets))
+        self.assertEqual("https://best-assets.bc", md.assets[0].href)
+        self.assertEqual(1, len(md.item_assets))
+        self.assertEqual("I have a type", md.item_assets[0].type)
+        self.assertEqual(3, len(md.providers))
+        self.assertEqual("i am the worst provider!", md.providers[1].description)
+        self.assertEqual("i am an ok provider!", md.providers[2].description)
+        self.assertEqual(["producer", "host"], md.providers[2].roles)
+
+        self.assertEqual(4, len(md.summaries))
+        self.assertListEqual(["id", "geometry"], md.summaries["columns"])
+        self.assertDictEqual({"min": "-170", "max": "170"}, md.summaries["x_range"])
+        self.assertDictEqual({"min": "-80", "max": "80"}, md.summaries["y_range"])
+        self.assertEqual(
+            "this is a complex schema stored in a string", md.summaries["schema"]
+        )
+
+    def test_get_default_spatial_extent(self):
+        sql = "SELECT geodb_get_metadata('some_other_collection')"
+        self._cursor.execute(sql)
+        result = self._cursor.fetchone()[0]
+        md = Metadata.from_json(result)
+        self.assertEqual("I am something else", md.title)

--- a/tests/sql/test_sql_metadata_functions.py
+++ b/tests/sql/test_sql_metadata_functions.py
@@ -210,6 +210,17 @@ class GeoDBSQLMDTest(unittest.TestCase):
             md.stac_extensions,
         )
 
+        keywords_json = json.dumps(["land", "sea", "whatever"])
+        self._cursor.execute(
+            "SELECT geodb_set_metadata_field('keywords', %s, 'land_use', 'geodb_user');",
+            (keywords_json,),
+        )
+        md = self._fetch_md(geodb, mockdb)
+        self.assertListEqual(
+            ["land", "sea", "whatever"],
+            md.keywords,
+        )
+
         sql = "SELECT geodb_set_metadata_field('links', '[{\"href\": \"https://link.com\", \"rel\": \"parent\"}]', 'land_use', 'geodb_user')"
         self._cursor.execute(sql)
         md = self._fetch_md(geodb, mockdb)

--- a/tests/sql/test_sql_metadata_functions.py
+++ b/tests/sql/test_sql_metadata_functions.py
@@ -197,8 +197,13 @@ class GeoDBSQLMDTest(unittest.TestCase):
         md = self._fetch_md(geodb, mockdb)
         self.assertEqual("MIT", md.license)
 
-        sql = "SELECT geodb_set_metadata_field('stac_extensions', '[\"https://stac-extensions.github.io/authentication/v1.1.0/schema.json\"]', 'land_use', 'geodb_user')"
-        self._cursor.execute(sql)
+        stac_ext_json = json.dumps(
+            ["https://stac-extensions.github.io/authentication/v1.1.0/schema.json"]
+        )
+        self._cursor.execute(
+            "SELECT geodb_set_metadata_field('stac_extensions', %s, 'land_use', 'geodb_user');",
+            (stac_ext_json,),
+        )
         md = self._fetch_md(geodb, mockdb)
         self.assertListEqual(
             ["https://stac-extensions.github.io/authentication/v1.1.0/schema.json"],

--- a/xcube_geodb/core/db_interface.py
+++ b/xcube_geodb/core/db_interface.py
@@ -1,0 +1,435 @@
+# The MIT License (MIT)
+# Copyright (c) 2025 by the xcube team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+import json
+import urllib
+from functools import cached_property
+from typing import Union, Dict, Sequence, Optional
+
+import requests
+
+from xcube_geodb.core.error import GeoDBError
+
+
+class DbInterface:
+    def __init__(
+        self,
+        server_url,
+        server_port,
+        gs_server_url,
+        gs_server_port,
+        auth_mode,
+        auth_client_id,
+        auth_client_secret,
+        auth_username,
+        auth_password,
+        auth_access_token,
+        auth_domain,
+        auth_aud,
+        auth_access_token_uri,
+    ):
+        self._auth_access_token_uri = auth_access_token_uri
+        self._auth_mode = auth_mode
+        self._auth_aud = auth_aud
+        self._auth_domain = auth_domain
+        self._auth_access_token = auth_access_token
+        self._auth_password = auth_password
+        self._auth_username = auth_username
+        self._auth_client_secret = auth_client_secret
+        self._auth_client_id = auth_client_id
+        self._gs_server_url = gs_server_url
+        self._gs_server_port = gs_server_port
+        self._server_port = server_port
+        self._server_url = server_url
+
+    @property
+    def auth_access_token(self) -> str:
+        """
+        Get the user's access token.
+
+        Returns:
+            The current authentication access_token
+
+        Raises:
+            GeoDBError on missing ipython shell
+        """
+
+        access_token_uri = self._auth_access_token_uri
+
+        return (
+            self._auth_access_token
+            or self._get_geodb_client_credentials_access_token(
+                token_uri=access_token_uri
+            )
+        )
+
+    def post(
+        self,
+        path: str,
+        payload: Union[Dict, Sequence],
+        params: Optional[Dict] = None,
+        headers: Optional[Dict] = None,
+        raise_for_status: bool = True,
+    ) -> requests.models.Response:
+        """
+
+        Args:
+            headers [Optional[Dict]]: Request headers. Allows Overriding common header entries.
+            path (str): API path
+            payload (Union[Dict, Sequence]): Post body as Dict or Sequence. Will be dumped to JSON
+            params Optional[Dict]: Request parameters
+            raise_for_status (bool): raise or not if status is not 200-299 [True]
+        Returns:
+            requests.models.Response: A Request object
+
+        Raises:
+            GeoDBError: If the database raises an error
+            HttpError: If the request fails
+        """
+
+        common_headers = self._get_common_headers()
+
+        if headers is not None:
+            common_headers.update(headers)
+
+        r = None
+        try:
+            if common_headers["Content-type"] == "text/csv":
+                r = requests.post(
+                    self._get_full_url(path=path),
+                    data=payload,
+                    params=params,
+                    headers=common_headers,
+                )
+            else:
+                r = requests.post(
+                    self._get_full_url(path=path),
+                    json=payload,
+                    params=params,
+                    headers=common_headers,
+                )
+            if raise_for_status:
+                r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            raise GeoDBError(r.text)
+
+        return r
+
+    def get(self, path: str, params: Optional[Dict] = None) -> requests.models.Response:
+        """
+
+        Args:
+            path (str): API path
+            params (Optional[Dict]): Request parameters
+
+        Returns:
+            requests.models.Response: A Response object
+
+        Raises:
+            GeoDBError: If the database raises an error
+            HttpError: If the request fails
+        """
+
+        r = None
+        try:
+            r = requests.get(
+                self._get_full_url(path=path),
+                params=params,
+                headers=(self._get_common_headers()),
+            )
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            raise GeoDBError(r.content)
+
+        return r
+
+    def delete(
+        self, path: str, params: Optional[Dict] = None, headers: Optional[Dict] = None
+    ) -> requests.models.Response:
+        """
+
+        Args:
+            headers (Optional[Dict]): Request headers. Allows Overriding common header entries.
+            path (str): API path
+            params (Optional[Dict]): Request parameters
+
+        Returns:
+            requests.models.Response: A Request object
+
+        Raises:
+            GeoDBError: If the database raises an error
+            HttpError: If the request fails
+        """
+
+        common_headers = self._get_common_headers()
+        headers = (
+            common_headers.update(headers) if headers else self._get_common_headers()
+        )
+
+        r = None
+        try:
+            r = requests.delete(
+                self._get_full_url(path=path), params=params, headers=headers
+            )
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            raise GeoDBError(r.text)
+        return r
+
+    def patch(
+        self,
+        path: str,
+        payload: Union[Dict, Sequence],
+        params: Optional[Dict] = None,
+        headers: Optional[Dict] = None,
+    ) -> requests.models.Response:
+        """
+
+        Args:
+            headers (Optional[Dict]): Request headers. Allows Overriding common header entries.
+            payload (Union[Dict, Sequence]): Post body as Dict. Will be dumped to JSON
+            path (str): API path
+            params (Optional[Dict]): Request parameters
+
+        Returns:
+            requests.models.Response: A Request object
+
+        Raises:
+            GeoDBError: If the database raises an error
+            HttpError: If the request fails
+        """
+
+        common_headers = self._get_common_headers()
+        headers = (
+            common_headers.update(headers) if headers else self._get_common_headers()
+        )
+
+        r = None
+        try:
+            r = requests.patch(
+                self._get_full_url(path=path),
+                json=payload,
+                params=params,
+                headers=headers,
+            )
+            r.raise_for_status()
+        except requests.HTTPError:
+            raise GeoDBError(r.text)
+        return r
+
+    def put(
+        self,
+        path: str,
+        payload: Union[Dict, Sequence],
+        params: Optional[Dict] = None,
+        headers: Optional[Dict] = None,
+    ) -> requests.models.Response:
+        """
+
+        Args:
+            headers (Optional[Dict]): Request headers. Allows Overriding common header entries.
+            payload (Union[Dict, Sequence]): Post body as Dict. Will be dumped to JSON
+            path (str): API path
+            params (Optional[Dict]): Request parameters
+
+        Returns:
+            requests.models.Response: A Request object
+
+        Raises:
+            GeoDBError: If the database raises an error
+        """
+
+        common_headers = self._get_common_headers()
+        headers = (
+            common_headers.update(headers) if headers else self._get_common_headers()
+        )
+
+        r = None
+        try:
+            r = requests.put(
+                self._get_full_url(path=path),
+                json=payload,
+                params=params,
+                headers=headers,
+            )
+            r.raise_for_status()
+            return r
+        except requests.HTTPError:
+            raise GeoDBError(r.text)
+
+    def _get_common_headers(self):
+        if self._auth_mode == "none":
+            return {
+                "Prefer": "return=representation",
+                "Content-type": "application/json",
+            }
+        else:
+            return {
+                "Prefer": "return=representation",
+                "Content-type": "application/json",
+                "Authorization": f"Bearer {self.auth_access_token}",
+            }
+
+    def _get_full_url(self, path: str) -> str:
+        """
+
+        Args:
+            path (str): PostgREST API path
+
+        Returns:
+            str: Full URL and path
+        """
+
+        server_url = self._server_url
+        server_port = self._server_port
+
+        if "services/xcube_geoserv" in path:
+            server_url = self._gs_server_url
+            server_port = self._gs_server_port
+
+        if self.use_winchester_gs and "geodb_geoserver" in path:
+            server_url = self._gs_server_url
+            server_port = None
+
+        if server_port:
+            return f"{server_url}:{server_port}{path}"
+        else:
+            return f"{server_url}{path}"
+
+    def _get_geodb_client_credentials_access_token(
+        self, token_uri: str = "/oauth/token", is_json: bool = True
+    ) -> str:
+        """
+        Get access token from client credentials
+
+        Args:
+            token_uri (str): oauth2 token URI
+            is_json: whether the request has to be of content type json
+
+        Returns:
+             An access token
+
+        Raises:
+            GeoDBError, HttpError
+        """
+
+        if self._auth_mode == "client-credentials":
+            self._raise_for_invalid_client_credentials_cfg()
+            payload = {
+                "client_id": self._auth_client_id,
+                "client_secret": self._auth_client_secret,
+                "audience": self._auth_aud,
+                "grant_type": "client_credentials",
+            }
+            headers = {"content-type": "application/json"} if is_json else None
+            r = requests.post(
+                self._auth_domain + token_uri, json=payload, headers=headers
+            )
+        elif self._auth_mode == "password":
+            self._raise_for_invalid_password_cfg()
+            payload = {
+                "client_id": self._auth_client_id,
+                "username": self._auth_username,
+                "password": self._auth_password,
+                "grant_type": "password",
+            }
+
+            if self._auth_aud:
+                payload["audience"] = self._auth_aud
+            if self._auth_client_secret:
+                payload["client_secret"] = self._auth_client_secret
+
+            headers = {"content-type": "application/x-www-form-urlencoded"}
+            r = requests.post(
+                self._auth_domain + token_uri, data=payload, headers=headers
+            )
+        else:
+            raise GeoDBError("System Error: auth mode unknown.")
+
+        r.raise_for_status()
+
+        data = r.json()
+
+        try:
+            self._auth_access_token = data["access_token"]
+            return data["access_token"]
+        except KeyError:
+            raise GeoDBError(
+                "The authorization request did not return an access token."
+            )
+
+    def _raise_for_invalid_client_credentials_cfg(self) -> bool:
+        """
+        Raise when the client-credentials configuration is wrong.
+
+        Returns:
+             True on success
+
+        Raises:
+            GeoDBError on invalid configuration
+        """
+        if (
+            self._auth_client_id
+            and self._auth_client_secret
+            and self._auth_aud
+            and self._auth_mode == "client-credentials"
+        ):
+            return True
+        else:
+            raise GeoDBError("System: Invalid client_credentials configuration.")
+
+    def _raise_for_invalid_password_cfg(self) -> bool:
+        """
+        Raise when the password configuration is wrong.
+
+        Returns:
+             True on success
+
+        Raises:
+            GeoDBError on invalid configuration
+        """
+        if (
+            self._auth_username
+            and self._auth_password
+            and self._auth_client_id
+            and self._auth_mode == "password"
+        ):
+            return True
+        else:
+            raise GeoDBError("System: Invalid password flow configuration")
+
+    @cached_property
+    def use_winchester_gs(self) -> bool:
+        try:
+            # check if Winchester is the interface to the Geoserver:
+            # extract base URL from the authentication URL and retrieve the server's meta
+            # information, look for 'winchester' in its list of APIs. Returns "False" if
+            # the meta information is structured differently, or does not contain
+            # the 'winchester'-API.
+            p = urllib.parse.urlparse(self._auth_domain)
+            url = f"{p.scheme}://{p.netloc}"
+            r = requests.get(url)
+            apis = json.loads(r.content.decode())["apis"]
+            for api in apis:
+                if "winchester" in api["name"]:
+                    return True
+        except:
+            pass
+        return False

--- a/xcube_geodb/core/error.py
+++ b/xcube_geodb/core/error.py
@@ -1,0 +1,24 @@
+# The MIT License (MIT)
+# Copyright (c) 2025 by the xcube team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+
+class GeoDBError(ValueError):
+    pass

--- a/xcube_geodb/core/geodb.py
+++ b/xcube_geodb/core/geodb.py
@@ -2609,17 +2609,22 @@ class GeoDBClient(object):
             database (str): The database to set the metadata field for
         """
         database = database or self.database
+        try:
+            jsonified_value = json.dumps(json.loads(value))
+        except (json.JSONDecodeError, TypeError):
+            # cannot parse as json -> wrap in double quotes
+            jsonified_value = f'"{value}"'
 
         path = "/rpc/geodb_set_metadata_field"
         payload = {
             "field": field,
-            "value": f"{value}",
+            "value": jsonified_value,
             "collection": collection,
             "db": database,
         }
 
         try:
-            self._db_interface.post(path=path, payload=payload).json()
+            self._db_interface.post(path=path, payload=payload)
         except GeoDBError as e:
             return self._maybe_raise(e, return_df=True)
 

--- a/xcube_geodb/core/geodb.py
+++ b/xcube_geodb/core/geodb.py
@@ -2628,7 +2628,7 @@ class GeoDBClient(object):
             >>> GeoDBClient.set_metadata_field("temporal_extent", [['2018-01-01T00:00:00Z', None], "my_collection")
         """
         database = database or self.database
-        if isinstance(value, str):
+        if field == "title" or field == "description" or field == "license":
             jsonified_value = f'"{value}"'
         elif field == "keywords" or field == "stac_extensions":
             value: List[str]
@@ -2812,37 +2812,3 @@ class GeoDBClient(object):
             payload=event,
             headers={"Prefer": "params=single-object"},
         )
-
-    @staticmethod
-    def setup(
-        host: Optional[str] = None,
-        port: Optional[str] = None,
-        user: Optional[str] = None,
-        passwd: Optional[str] = None,
-        dbname: Optional[str] = None,
-        conn: Optional[any] = None,
-    ):
-        """
-        Sets up  the database. Needs DB credentials and the database user requires CREATE TABLE/FUNCTION grants.
-        """
-        host = host or os.getenv("GEODB_DB_HOST")
-        port = port or os.getenv("GEODB_DB_PORT")
-        user = user or os.getenv("GEODB_DB_USER")
-        passwd = passwd or os.getenv("GEODB_DB_PASSWD")
-        dbname = dbname or os.getenv("GEODB_DB_DBNAME")
-
-        try:
-            import psycopg2
-        except ImportError:
-            raise GeoDBError("You need to install psycopg2 first to run this module.")
-
-        conn = conn or psycopg2.connect(
-            host=host, port=port, user=user, password=passwd, dbname=dbname
-        )
-        cursor = conn.cursor()
-
-        with open("xcube_geodb/sql/geodb.sql") as sql_file:
-            sql_create = sql_file.read()
-            cursor.execute(sql_create)
-
-        conn.commit()

--- a/xcube_geodb/core/geodb.py
+++ b/xcube_geodb/core/geodb.py
@@ -769,8 +769,8 @@ class GeoDBClient(object):
         """
 
         database = database or self.database
-        collections = [database + "_" + collection for collection in collections]
         payload = {
+            "database": database,
             "collections": collections,
             "cascade": "TRUE" if cascade else "FALSE",
         }
@@ -778,9 +778,11 @@ class GeoDBClient(object):
         try:
             self._db_interface.post(path="/rpc/geodb_drop_collections", payload=payload)
             for collection in collections:
-                self._log_event(EventType.DROPPED, f"collection {collection}")
+                self._log_event(
+                    EventType.DROPPED, f"collection {database}_{collection}"
+                )
             self._refresh_capabilities()
-            return Message(f"Collection {str(collections)} deleted")
+            return Message(f"Collections {database}_{str(collections)} deleted")
         except GeoDBError as e:
             return self._maybe_raise(e)
 

--- a/xcube_geodb/core/geodb.py
+++ b/xcube_geodb/core/geodb.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse
 
 from xcube_geodb.const import MINX, MINY, MAXX, MAXY
 from xcube_geodb.core.message import Message
+from xcube_geodb.core.metadata import Metadata
 from xcube_geodb.defaults import GEODB_DEFAULTS
 from xcube_geodb.version import version
 import warnings
@@ -2777,6 +2778,16 @@ class GeoDBClient(object):
         }
         r = self._post(path=path, payload=payload)
         return int(r.text) > 0
+
+    def get_metadata(self, collection: str, database: Optional[str] = None) -> Metadata:
+        database = database or self.database
+        dn = f"{database}_{collection}"
+
+        path = "/rpc/geodb_get_metadata"
+        payload = {"collection": dn}
+
+        result = self._post(path=path, payload=payload).json()
+        return Metadata.from_json(result)
 
     @property
     def auth_access_token(self) -> str:

--- a/xcube_geodb/core/metadata.py
+++ b/xcube_geodb/core/metadata.py
@@ -1,0 +1,419 @@
+# The MIT License (MIT)
+# Copyright (c) 2025 by the xcube team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+from typing import List, Optional, Dict, Any, Union, TypeAlias, Literal
+
+
+# noinspection PyShadowingBuiltins
+class Range(dict):  # inheriting from dict to make it JSON serializable
+    def __init__(self, min: Union[float, str], max: Union[float, str]):
+        dict.__init__(self)
+        self["min"] = min
+        self["min"] = max
+
+
+JSONSchema: TypeAlias = str
+SpatialExtent: TypeAlias = List[List[float]]
+TemporalExtent: TypeAlias = List[List[Optional[str]]]
+Summary: TypeAlias = List[Any] | Range | JSONSchema
+Relation = Literal["self", "root", "parent", "child", "collection", "item"]
+valid_roles = ["licensor", "producer", "processor", "host"]
+
+
+class Provider:
+    def __init__(
+        self, name: str, description: str = "", roles: List[str] = None, url: str = None
+    ):
+        self._name = name
+        self._description = description
+        self._roles = roles if roles else []
+        if not set(self._roles).issubset(valid_roles):
+            raise ValueError(
+                f"Invalid set of roles provided: {roles}; valid roles are: {valid_roles}."
+            )
+        self._url = url
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def roles(self) -> List[str]:
+        return self._roles
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+    @description.setter
+    def description(self, value):
+        self._description = value
+
+    @url.setter
+    def url(self, value):
+        self._url = value
+
+    @roles.setter
+    def roles(self, value):
+        self._roles = value
+
+    @staticmethod
+    def from_json(provider_spec: Dict[str, Union[str, List[str]]]):
+        p = Provider(
+            provider_spec["name"],
+        )
+        if "description" in provider_spec:
+            p.description = provider_spec["description"]
+
+        if "url" in provider_spec:
+            p.url = provider_spec["url"]
+
+        if "roles" in provider_spec:
+            p.roles = provider_spec["roles"]
+
+        return p
+
+
+# noinspection PyShadowingBuiltins
+class Link:
+    def __init__(
+        self,
+        href: str,
+        rel: Relation,
+        type: Optional[str],
+        title: Optional[str],
+        method: Optional[str],
+        headers: Optional[Dict[str, Union[str, List[str]]]],
+        body: Optional[Any],
+    ):
+        self._href = href
+        self._rel = rel
+        self._type = type
+        self._title = title
+        self._method = method
+        self._headers = headers
+        self._body = body
+
+    @staticmethod
+    def from_json(link_spec):
+        return Link(
+            link_spec["href"],
+            link_spec["rel"],
+            link_spec["type"] if "type" in link_spec else None,
+            link_spec["title"] if "title" in link_spec else None,
+            link_spec["method"] if "method" in link_spec else None,
+            link_spec["headers"] if "headers" in link_spec else None,
+            link_spec["body"] if "body" in link_spec else None,
+        )
+
+    @property
+    def href(self) -> str:
+        return self._href
+
+    @property
+    def rel(self) -> Relation:
+        return self._rel
+
+    @property
+    def type(self) -> Optional[str]:
+        return self._type
+
+    @property
+    def title(self) -> Optional[str]:
+        return self._title
+
+    @property
+    def method(self) -> Optional[str]:
+        return self._method
+
+    @property
+    def body(self) -> Optional[Any]:
+        return self._body
+
+    @property
+    def headers(self) -> Optional[Dict[str, Union[str, List[str]]]]:
+        return self._headers
+
+
+# noinspection PyShadowingBuiltins
+class Asset:
+    def __init__(
+        self,
+        href: str,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        type: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+    ):
+        self._href = href
+        self._title = title
+        self._description = description
+        self._type = type
+        self._roles = roles
+
+    @property
+    def href(self) -> str:
+        return self._href
+
+    @property
+    def title(self) -> Optional[str]:
+        if self._title:
+            return self._title
+        return None
+
+    @property
+    def description(self) -> Optional[str]:
+        if self._description:
+            return self._description
+        return None
+
+    @description.setter
+    def description(self, value):
+        self._description = value
+
+    @property
+    def type(self) -> Optional[str]:
+        if self._type:
+            return self._type
+        return None
+
+    @property
+    def roles(self) -> Optional[List[str]]:
+        if self._roles:
+            return self._roles
+        return None
+
+    @staticmethod
+    def from_json(asset_spec: Dict[str, Union[str, List[str]]]):
+        asset = Asset(
+            asset_spec["href"],
+        )
+        if "description" in asset_spec:
+            asset.description = asset_spec["description"]
+        if "title" in asset_spec:
+            asset.title = asset_spec["title"]
+        if "type" in asset_spec:
+            asset.type = asset_spec["type"]
+        if "roles" in asset_spec:
+            asset.roles = asset_spec["roles"]
+
+        return asset
+
+    @type.setter
+    def type(self, value):
+        self._type = value
+
+    @roles.setter
+    def roles(self, value):
+        self._roles = value
+
+    @title.setter
+    def title(self, value):
+        self._title = value
+
+
+# noinspection PyShadowingBuiltins
+class ItemAsset:
+    def __init__(
+        self,
+        title: Optional[str],
+        description: Optional[str],
+        type: Optional[str],
+        roles: Optional[List[str]],
+    ):
+        self._title = title
+        self._description = description
+        self._type = type
+        self._roles = roles
+
+
+# noinspection PyShadowingBuiltins
+class Metadata:
+    """
+    General idea: store properties for the metadata fields that are specified by the
+    STAC collection specification (https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection
+    -spec.md).
+
+    This class is intended not to contain any logic, rather, its purpose is to reflect the
+    database state.
+
+
+    Disregard this for this class:
+    Also, allow for generic extra fields:
+        - set_binary_metadata(field_name, blob)
+        - set_string_metadata(field_name, string)
+        - set_number_metadata(field_name, number)
+        - set_time_metadata(field_name, datetime)
+        - set_object_metadata(field_name, Anything convertible to JSON)
+
+    Some metadata fields can be extracted automatically (see
+    xcube_geodb_openeo.core.geodb_datasource.GeoDBVectorSource.get_metadata), however,
+    if they have been deliberately set using one of the set_methods, that value takes
+    precedence.
+    """
+
+    def __init__(
+        self,
+        id: str,
+        title: str,
+        links: List[Link],
+        spatial_extent: Optional[SpatialExtent] = None,
+        temporal_extent: Optional[TemporalExtent] = None,
+        description: str = "No description available",
+        license: str = "proprietary",
+        providers: Optional[List[Provider]] = None,
+        stac_extensions: Optional[List[str]] = None,
+        keywords: Optional[List[str]] = None,
+        summaries: Optional[Dict[str, Summary]] = None,
+        assets: Optional[Dict[str, Asset]] = None,
+        item_assets: Optional[Dict[str, ItemAsset]] = None,
+    ):
+        if spatial_extent is None:
+            spatial_extent = [[-180.0, -90.0, 180.0, 90.0]]
+        if temporal_extent is None:
+            temporal_extent = [[None, None]]
+        self._id = id
+        self._title = title
+        self._links = links
+        self._spatial_extent = spatial_extent
+        self._temporal_extent = temporal_extent
+        self._description = description
+        self._stac_extensions = stac_extensions
+        self._keywords = keywords if keywords else []
+        self._providers = providers if providers else []
+        self._license = license
+        self._summaries = summaries if summaries else {}
+        self._assets = assets if assets else {}
+        self._item_assets = item_assets if item_assets else {}
+
+    @property
+    def type(self) -> str:
+        return "Collection"
+
+    @property
+    def title(self) -> str:
+        return self._title
+
+    @property
+    def stac_version(self) -> str:
+        return "1.1.0"
+
+    @property
+    def stac_extensions(self) -> Optional[List[str]]:
+        return self._stac_extensions
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def keywords(self) -> Optional[List[str]]:
+        return self._keywords
+
+    @property
+    def license(self) -> str:
+        return self._license
+
+    @property
+    def providers(self) -> Optional[List[Provider]]:
+        return self._providers
+
+    @property
+    def links(self) -> List[Link]:
+        return self._links
+
+    @property
+    def summaries(self) -> Optional[Dict[str, List[Any] | Range | JSONSchema]]:
+        return self._summaries
+
+    @property
+    def spatial_extent(self) -> SpatialExtent:
+        return self._spatial_extent
+
+    @property
+    def temporal_extent(self) -> TemporalExtent:
+        return self._temporal_extent
+
+    @property
+    def assets(self) -> Optional[Dict[str, Asset]]:
+        return self._assets
+
+    @property
+    def item_assets(self) -> Optional[Dict[str, ItemAsset]]:
+        return self._item_assets
+
+    @staticmethod
+    def _get_providers(json: Dict[str, Any]) -> Optional[List[Provider]]:
+        if "providers" not in json:
+            return None
+        result = []
+        for provider_spec in json["providers"]:
+            result.append(Provider.from_json(provider_spec))
+        return result
+
+    @staticmethod
+    def _get_assets(json: Dict[str, Any]) -> Optional[Dict[str, Asset]]:
+        if "assets" not in json:
+            return None
+        result: dict[str, Asset] = {}
+        for name, asset_spec in json["assets"].items():
+            result[name] = Asset.from_json(asset_spec)
+        return result
+
+    @staticmethod
+    def _get_links(json: Dict[str, Any]) -> List[Link]:
+        if "links" not in json:
+            return []
+        result = []
+        for link_spec in json["links"]:
+            result.append(Link.from_json(link_spec))
+        return result
+
+    @staticmethod
+    def from_json(json: Dict[str, Any]):
+        providers = Metadata._get_providers(json)
+        assets = Metadata._get_assets(json)
+        links = Metadata._get_links(json)
+        summaries = json["summaries"] if "summaries" in json else {}
+        stac_extensions = json["stac_extensions"] if "stac_extensions" in json else []
+        title = json["title"] if "title" in json else None
+        keywords = json["keywords"] if "keywords" in json else None
+        return Metadata(
+            id=json["id"],
+            title=title,
+            links=links,
+            spatial_extent=json["spatial_extent"],
+            temporal_extent=json["temporal_extent"],
+            description=json["description"],
+            license=json["license"],
+            providers=providers,
+            stac_extensions=stac_extensions,
+            keywords=keywords,
+            summaries=summaries,
+            assets=assets,
+        )

--- a/xcube_geodb/core/metadata.py
+++ b/xcube_geodb/core/metadata.py
@@ -493,6 +493,42 @@ class Metadata:
         self._assets = assets if assets else []
         self._item_assets = item_assets if item_assets else []
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"id={self._id}, "
+            f"title={self._title}, "
+            f"links={self._links} links, "
+            f"spatial_extent={self._spatial_extent}, "
+            f"temporal_extent={self._temporal_extent}, "
+            f"description={self._description}, "
+            f"license={self._license}, "
+            f"providers={self._providers} providers, "
+            f"keywords={self._keywords}, "
+            f"assets={self._assets} assets, "
+            f"item_assets={self._item_assets} item assets)"
+        )
+
+    def __str__(self) -> str:
+        return "\n".join(
+            [
+                f"{self._title} [{self._id}]",
+                f"  Description: {self._description}",
+                f"  License: {self._license}",
+                f"  Providers: {', '.join(p.name for p in self._providers) if self._providers else 'None'}",
+                f"  Keywords: {', '.join(self._keywords) if self._keywords else 'None'}",
+                f"  Links: {self._links}",
+                f"  Assets: {self._assets}",
+                f"  Item Assets: {self._item_assets}",
+                f"  Spatial extent: {self._spatial_extent}"
+                if self._spatial_extent
+                else "  Spatial extent: None",
+                f"  Temporal extent: {self._temporal_extent}"
+                if self._temporal_extent
+                else "  Temporal extent: None",
+            ]
+        )
+
     @property
     def type(self) -> str:
         return "Collection"

--- a/xcube_geodb/core/metadata.py
+++ b/xcube_geodb/core/metadata.py
@@ -329,17 +329,31 @@ class MetadataManager:
         assets = self._get_assets(json)
         item_assets = self._get_item_assets(json)
         links = self._get_links(json)
-        summaries = json["basic"]["summaries"] if "summaries" in json["basic"] else {}
+        summaries = (
+            json["basic"]["summaries"]
+            if "summaries" in json["basic"] and json["basic"]["summaries"] is not None
+            else {}
+        )
         stac_extensions = (
             json["basic"]["stac_extensions"]
             if "stac_extensions" in json["basic"]
+            and json["basic"]["stac_extensions"] is not None
             else []
         )
-        title = json["basic"]["title"] if "title" in json["basic"] else ""
-        keywords = json["basic"]["keywords"] if "keywords" in json["basic"] else []
+        title = (
+            json["basic"]["title"]
+            if "title" in json["basic"] and json["basic"]["title"] is not None
+            else ""
+        )
+        keywords = (
+            json["basic"]["keywords"]
+            if "keywords" in json["basic"] and json["basic"]["keywords"] is not None
+            else []
+        )
         spatial_extent = (
             json["basic"]["spatial_extent"]
             if "spatial_extent" in json["basic"]
+            and json["basic"]["spatial_extent"] is not None
             else None
         )
         if not spatial_extent:
@@ -381,8 +395,8 @@ class MetadataManager:
             path,
             payload={
                 "collection": f"{collection}_{database}",
-                "database": database,
-                "spatial_extent": spatial_extent,
+                "db": database,
+                "se": spatial_extent,
                 "srid": int(srid),
             },
         )
@@ -452,8 +466,8 @@ class Metadata:
         links: List[Link],
         spatial_extent: Optional[SpatialExtent],
         temporal_extent: Optional[TemporalExtent] = None,
-        description: str = "No description available",
-        license: str = "proprietary",
+        description: Optional[str] = None,
+        license: Optional[str] = None,
         providers: Optional[List[Provider]] = None,
         stac_extensions: Optional[List[str]] = None,
         keywords: Optional[List[str]] = None,
@@ -468,11 +482,11 @@ class Metadata:
         self._links = links
         self._spatial_extent = spatial_extent
         self._temporal_extent = temporal_extent
-        self._description = description
+        self._description = description if description else "No description available"
         self._stac_extensions = stac_extensions
         self._keywords = keywords if keywords else []
         self._providers = providers if providers else []
-        self._license = license
+        self._license = license if license else "proprietary"
         self._summaries = summaries if summaries else {}
         self._assets = assets if assets else []
         self._item_assets = item_assets if item_assets else []

--- a/xcube_geodb/core/metadata.py
+++ b/xcube_geodb/core/metadata.py
@@ -371,8 +371,12 @@ class MetadataManager:
         if not spatial_extent:
             # get from database
             bbox = self._geodb.get_collection_bbox(collection, database)
-            srid = self._geodb.get_collection_srid(collection, database)
-            spatial_extent = [[bbox[0], bbox[1], bbox[2], bbox[3]]]
+            if bbox:
+                srid = self._geodb.get_collection_srid(collection, database)
+                spatial_extent = [[bbox[0], bbox[1], bbox[2], bbox[3]]]
+            else:
+                srid = "4326"
+                spatial_extent = [-180, -90, 180, 90]
             self._set_spatial_extent(spatial_extent, collection, database, srid)
         else:
             # reformat what we got from metadata table

--- a/xcube_geodb/core/metadata.py
+++ b/xcube_geodb/core/metadata.py
@@ -109,6 +109,12 @@ class Provider:
 
         return p
 
+    def __repr__(self):
+        return (
+            f"{{name = {self._name}, description = {self._description}, url = {self._url}, "
+            f"roles = {self._roles}}}"
+        )
+
 
 # noinspection PyShadowingBuiltins
 class Link:
@@ -170,6 +176,13 @@ class Link:
     def headers(self) -> Optional[Dict[str, Union[str, List[str]]]]:
         return self._headers
 
+    def __repr__(self):
+        return (
+            f"{{href = {self._href}, rel = {self._rel}, type = {self._type}, "
+            f"title = {self._title}, method = {self._method}, "
+            f"headers = {self._headers}, body = {self._body}}}"
+        )
+
 
 # noinspection PyShadowingBuiltins
 class Asset:
@@ -219,6 +232,18 @@ class Asset:
             return self._roles
         return None
 
+    @title.setter
+    def title(self, value):
+        self._title = value
+
+    @type.setter
+    def type(self, value):
+        self._type = value
+
+    @roles.setter
+    def roles(self, value):
+        self._roles = value
+
     @staticmethod
     def from_json(asset_spec: Dict[str, Union[str, List[str]]]):
         asset = Asset(
@@ -235,17 +260,11 @@ class Asset:
 
         return asset
 
-    @type.setter
-    def type(self, value):
-        self._type = value
-
-    @roles.setter
-    def roles(self, value):
-        self._roles = value
-
-    @title.setter
-    def title(self, value):
-        self._title = value
+    def __repr__(self):
+        return (
+            f"{{href = {self.href}, description = {self._description}, title = {self._title}, "
+            f"type = {self._type}, roles = {self._roles}}}"
+        )
 
 
 # noinspection PyShadowingBuiltins
@@ -290,6 +309,18 @@ class ItemAsset:
             return self._roles
         return None
 
+    @title.setter
+    def title(self, value):
+        self._title = value
+
+    @type.setter
+    def type(self, value):
+        self._type = value
+
+    @roles.setter
+    def roles(self, value):
+        self._roles = value
+
     @staticmethod
     def from_json(asset_spec: Dict[str, Union[str, List[str]]]):
         item_asset = ItemAsset()
@@ -304,17 +335,11 @@ class ItemAsset:
 
         return item_asset
 
-    @type.setter
-    def type(self, value):
-        self._type = value
-
-    @roles.setter
-    def roles(self, value):
-        self._roles = value
-
-    @title.setter
-    def title(self, value):
-        self._title = value
+    def __repr__(self):
+        return (
+            f"{{description = {self._description}, title = {self._title}, "
+            f"type = {self._type}, roles = {self._roles}}}"
+        )
 
 
 class MetadataManager:
@@ -354,6 +379,7 @@ class MetadataManager:
             json["basic"]["spatial_extent"]
             if "spatial_extent" in json["basic"]
             and json["basic"]["spatial_extent"] is not None
+            and not json["basic"]["spatial_extent"] == []
             else None
         )
         if not spatial_extent:
@@ -394,7 +420,7 @@ class MetadataManager:
         self._db_interface.post(
             path,
             payload={
-                "collection": f"{collection}_{database}",
+                "collection": collection,
                 "db": database,
                 "se": spatial_extent,
                 "srid": int(srid),
@@ -505,13 +531,7 @@ class Metadata:
 
     @property
     def stac_extensions(self) -> Optional[Sequence[str]]:
-        """
-        Retrieve the STAC extensions supported. Changes to the result object are not
-        reflected in the database.
-
-        :return: A copy of the STAC extensions list.
-        """
-        return list(self._stac_extensions)
+        return self._stac_extensions
 
     @property
     def id(self) -> str:

--- a/xcube_geodb/sql/geodb.sql
+++ b/xcube_geodb/sql/geodb.sql
@@ -1739,10 +1739,10 @@ BEGIN
     ELSIF field IN ('keywords', 'stac_extensions') THEN
         EXECUTE format('
             UPDATE geodb_collection_metadata.basic md
-            SET %s = %s
+            SET %s = ''%s''
             WHERE md.collection_name = ''%s''
               and md.database = ''%s'';'
-            , field, ARRAY(SELECT json_array_elements(value)), collection, db);
+            , field, ARRAY(SELECT json_array_elements_text(value)), collection, db);
     ELSIF field = 'links' THEN
         DELETE
         FROM geodb_collection_metadata.link li

--- a/xcube_geodb/version.py
+++ b/xcube_geodb/version.py
@@ -1,1 +1,1 @@
-version = "1.0.11dev"
+version = "1.1.0"

--- a/xcube_geodb/version.py
+++ b/xcube_geodb/version.py
@@ -1,1 +1,1 @@
-version = "1.1.0"
+version = "1.1.0dev"


### PR DESCRIPTION
This PR closes #123. Users can now set and retrieve STAC-compliant metadata, using the new functions:
- `geodb.get_metadata("my_collection")` which returns an instance of the new `Metadata`-class
- `geodb.set_metadata_field("the_field", "my_value", "my_collection")`

The usage is documented in the notebook `docs/source/notebooks/geodb_test_metadata_support.ipynb`. The updated SQL is deployed on the development geoDB, which can be used for testing.

Checklist:

* [x] Issue has been created for change
* [x] Added docstrings and API docs for any new/modified user-facing classes and functions
* [x] New/modified features documented in `docs/source/*`
* [x] Changes documented in `CHANGES.md`
* [x] GitHub CI passes
* [x] Test coverage remains or increases (target 100%)